### PR TITLE
99 add additional shape file checking to afp pre processing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1199,6 +1199,13 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
   df02 <- sf::st_join(df01.sf |> dplyr::filter(!Admin2GUID %in% invalid.shapes$GUID), valid.shapes, left = T) |>
     dplyr::filter(yronset >= yr.st & yronset <= yr.end)
 
+  #second st_join is for invalid shapes and those attached cases, turning off s2
+  sf_use_s2(F)
+  df03 <- sf::st_join(df01.sf |> dplyr::filter(!Admin2GUID %in% invalid.shapes$GUID), invalid.shapes, left = T) |>
+    dplyr::filter(yronset >= yr.st & yronset <= yr.end)
+  sf_use_s2(T)
+
+  cli::cli_process_done()
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1195,6 +1195,11 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::slice(row.num.2) |>
     dplyr::select(GUID, ADM1_GUID, ADM0_GUID, yr.st, yr.end, SHAPE)
 
+  #do 2 seperate st_joins the first, df02, is for valid shapes and those attached cases
+  df02 <- sf::st_join(df01.sf |> dplyr::filter(!Admin2GUID %in% invalid.shapes$GUID), valid.shapes, left = T) |>
+    dplyr::filter(yronset >= yr.st & yronset <= yr.end)
+
+
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2784,6 +2784,15 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
 
   global.dist.01 <- sirfunctions::load_clean_dist_sp()
+
+  #identify afp cases w/ bad adm2guids
+  cli::cli_process_start("Checking District GUIDs")
+  afp.noshape <- dplyr::anti_join(afp.linelist.fixed.03, global.dist.01, by=c("Admin2GUID"="GUID"))
+
+  tidypolis_io(obj = afp.noshape, io = "write", file_path = paste(polis_data_folder, "/Core_Ready_Files/AFP_epids_bad_guid.csv", sep = ""))
+
+  cli::cli_process_done()
+
   shape.file.names <- names(global.dist.01)
   shape.file.names <- shape.file.names[!shape.file.names %in% c("SHAPE")]
   col.afp.raw.01 <- colnames(afp.raw.01)
@@ -2953,9 +2962,6 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   afp.linelist.02 <- afp.linelist.01 |>
     dplyr::filter(surveillancetypename == "AFP") |>
     dplyr::distinct()# this gives us an AFP line list
-
-  # remove duplicates in afp linelist
-  afp.linelist.02 <- afp.linelist.02[!duplicated(afp.linelist.02$epid), ]
 
   cli::cli_process_done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1260,6 +1260,24 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::bind_rows(dropped.obs) |>
     dplyr::select(-c("GUID", "yr.st", "yr.end"))
 
+  df06$geometry <- NULL
+
+  #feed only cases with empty coordinates into st_sample (vars = GUID, nperarm, id, SHAPE)
+  empty.coord.01 <- empty.coord |>
+    tibble::as_tibble() |>
+    dplyr::group_by(Admin2GUID) |>
+    dplyr::summarise(nperarm = dplyr::n()) |>
+    dplyr::arrange(Admin2GUID) |>
+    dplyr::mutate(id = dplyr::row_number()) |>
+    dplyr::ungroup() |>
+    dplyr::filter(Admin2GUID != "{NA}")
+
+  empty.coord.02 <- global.dist.01 |>
+    dplyr::select(GUID) |>
+    dplyr::filter(GUID %in% empty.coord.01$Admin2GUID) |>
+    dplyr::left_join(empty.coord.01, by = c("GUID" = "Admin2GUID"))
+
+
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1349,6 +1349,12 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
 
   pt05$x <- NULL
   pt05$geometry <- NULL
+
+  #bind back placed point cases with df06 and finished
+  df07 <- dplyr::bind_rows(df06, pt05) |>
+    dplyr::select(-c("wrongAdmin1GUID", "wrongAdmin2GUID", "ADM1_GUID", "ADM0_GUID"))
+
+  return(df07)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1188,6 +1188,13 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
   valid.shapes <- global.dist.02 |>
     dplyr::slice(-row.num.2) |>
     dplyr::select(GUID, ADM1_GUID, ADM0_GUID, yr.st, yr.end, SHAPE)
+
+  cli::cli_process_start("Evaluating invalid district shapes")
+  #invalid shapes for which we'll turn off s2
+  invalid.shapes <- global.dist.02 |>
+    dplyr::slice(row.num.2) |>
+    dplyr::select(GUID, ADM1_GUID, ADM0_GUID, yr.st, yr.end, SHAPE)
+
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1171,6 +1171,15 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
   tidypolis_io(io = "write", file_path = paste0(polis_data_folder, "/Core_Ready_Files/afp_empty_coords.csv"),
                obj = empty.coord)
 
+  cli::cli_process_start("Spatially joining AFP cases to global districts")
+  #create sf object from lat lon and make global.dist valid
+  df01.sf <- df01 |>
+    dplyr::filter(!epid %in% empty.coord$epid) |>
+    dplyr::mutate(lon = polis.longitude,
+                  lat = polis.latitude) |>
+    sf::st_as_sf(coords = c(x = "lon" , y = "lat"), crs = 4326)
+
+  global.dist.02 <- sf::st_make_valid(global.dist.01)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1311,6 +1311,33 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     bind_rows()
 
   cli::cli_process_done()
+
+  pt01_joined <- dplyr::bind_cols(
+    pt01,
+    empty.coord.02 |>
+      tibble::as_tibble() |>
+      dplyr::select(GUID, nperarm) |>
+      tidyr::uncount(nperarm)
+  ) |>
+    dplyr::left_join(tibble::as_tibble(empty.coord.02) |>
+                       dplyr::select(-SHAPE),
+                     by = "GUID")
+
+  pt02 <- pt01_joined |>
+    tibble::as_tibble() |>
+    dplyr::select(-nperarm, -id) |>
+    dplyr::group_by(GUID)|>
+    dplyr::arrange(GUID, .by_group = TRUE) |>
+    dplyr::mutate(id = dplyr::row_number()) |>
+    as.data.frame()
+
+  pt03 <- empty.coord |>
+    dplyr::group_by(Admin2GUID) |>
+    dplyr::arrange(Admin2GUID, .by_group = TRUE) |>
+    dplyr::mutate(id = dplyr::row_number()) |>
+    dplyr::ungroup()
+
+  pt04 <- dplyr::full_join(pt03, pt02, by = c("Admin2GUID" = "GUID", "id"))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2886,6 +2886,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   cli::cli_process_done()
 
+  col.afp.raw.01 <- colnames(afp.raw.01)
   rm("afp.raw.01")
   gc()
   # Function to create lat & long for AFP cases
@@ -3342,7 +3343,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   cli::cli_process_start("Clearing memory")
 
   rm('afp.clean.01', 'afp.clean.light', 'afp.files.01', 'afp.files.02',
-      'afp.linelist.01', 'afp.linelist.02', 'afp.linelist.latlong',
+     'afp.linelist.01', 'afp.linelist.02', 'afp.linelist.latlong',
      'afp.missing.01', 'afp.missing.02', 'afp_metadata_comparison',
      'col.afp.raw.01', 'dup.epid', 'issuesbyCtry', 'issuesbyyear',
      'endyr', 'global.dist.01', 'in_new_and_old_but_modified',
@@ -3352,7 +3353,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
      'not.afp', 'not.afp.01', 'not_afp_metadata_comparison', 'old',
      'old.file', 'old_table_metadata', 'startyr',
      'unknown.afp', 'x', "afp.new", "afp.to.combine", "non.afp.new",
-     "non.afp.to.combine"
+     "non.afp.to.combine", "afp.noshape"
   )
 
   gc()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1202,7 +1202,7 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
 
   #second st_join is for invalid shapes and those attached cases, turning off s2
   sf_use_s2(F)
-  df03 <- sf::st_join(df01.sf |> dplyr::filter(!Admin2GUID %in% invalid.shapes$GUID), invalid.shapes, left = T) |>
+  df03 <- sf::st_join(df01.sf |> dplyr::filter(!Admin2GUID %in% valid.shapes$GUID), invalid.shapes, left = T) |>
     dplyr::filter(yronset >= yr.st & yronset <= yr.end)
   sf_use_s2(T)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1234,6 +1234,10 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::ungroup() |>
     dplyr::select(-n)
 
+  #fixed duplicates
+  dupes.fixed <- dplyr::bind_rows(dupes.01, dupes.02)
+
+  rm(dupes, dupes.01, dupes.02)
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2837,8 +2837,6 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
       wrongbothGUID = sum(wrongAdmin1GUID == "yes" & wrongAdmin2GUID == "yes")
     )
 
-
-
   rm("afp.linelist.01", "afp.linelist.fixed", "shapes", "shapenames")
 
   cli::cli_process_done()
@@ -2888,17 +2886,11 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   cli::cli_process_done()
 
-  shape.file.names <- names(global.dist.01)
-  shape.file.names <- shape.file.names[!shape.file.names %in% c("SHAPE")]
-  col.afp.raw.01 <- colnames(afp.raw.01)
   rm("afp.raw.01")
   gc()
   # Function to create lat & long for AFP cases
   afp.linelist.fixed.04 <- f.pre.stsample.01(afp.linelist.fixed.03, global.dist.01)
   rm("afp.linelist.fixed.03")
-
-  #vars created during stsample
-  stsample.vars <- c("id", "empty.01", "x")
 
   cli::cli_process_done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1277,7 +1277,40 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::filter(GUID %in% empty.coord.01$Admin2GUID) |>
     dplyr::left_join(empty.coord.01, by = c("GUID" = "Admin2GUID"))
 
+  cli::cli_process_start("Placing random points for cases with bad coordinates")
+  pt01 <- lapply(1:nrow(empty.coord.02), function(x){
 
+    tryCatch(
+      expr = {suppressMessages(sf::st_sample(empty.coord.02[x,], pull(empty.coord.02[x,], "nperarm"),
+                                             exact = T)) |> st_as_sf()},
+      error = function(e) {
+        guid = empty.coord.02[x, ]$GUID[1]
+        ctry_prov_dist_name = global.dist.01 |> filter(GUID == guid) |> select(ADM0_NAME, ADM1_NAME, ADM2_NAME)
+        cli::cli_alert_warning(paste0("Fixing errors for:\n",
+                                      "Country: ", ctry_prov_dist_name$ADM0_NAME,"\n",
+                                      "Province: ", ctry_prov_dist_name$ADM1_NAME, "\n",
+                                      "District: ", ctry_prov_dist_name$ADM2_NAME))
+
+        suppressWarnings(
+          {
+            sf_use_s2(F)
+            int <- empty.coord.02[x,] |> st_centroid(of_largest_polygon = T)
+            sf_use_s2(T)
+
+            st_buffer(int, dist = 3000) |>
+              st_sample(slice(empty.coord.02, x) |>
+                          pull(nperarm)) |>
+              st_as_sf()
+          }
+        )
+
+      }
+    )
+
+  }) |>
+    bind_rows()
+
+  cli::cli_process_done()
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1232,8 +1232,7 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::group_by(epid) |>
     dplyr::slice(1) |>
     dplyr::ungroup() |>
-    dplyr::select(-n) |>
-    dplyr::mutate(Admin2GUID = GUID)
+    dplyr::select(-n)
 
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1338,6 +1338,17 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::ungroup()
 
   pt04 <- dplyr::full_join(pt03, pt02, by = c("Admin2GUID" = "GUID", "id"))
+
+  pt05 <- pt04 |>
+    dplyr::bind_cols(
+      tibble::as_tibble(pt04$x),
+      sf::st_coordinates(pt04$x) |>
+        tibble::as_tibble() |>
+        dplyr::rename("lon" = "X", "lat" = "Y")) |>
+    dplyr::select(-id)
+
+  pt05$x <- NULL
+  pt05$geometry <- NULL
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3047,7 +3047,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
          emergence.group = `emergence.group(s)`
   ) |>
     dplyr::filter(!is.na(epid)) |>
-    dplyr::select(-c(shape.file.names, guid.check.vars, stsample.vars))
+    dplyr::select(-c(Admin2GUID, Admin1GUID, Admin0GUID))
 
   rm("afp.linelist.fixed.04")
   gc()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1168,7 +1168,7 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
   empty.coord <- df01 |>
     dplyr::filter(is.na(polis.latitude) | is.na(polis.longitude) | (polis.latitude == 0 & polis.longitude == 0))
 
-  tidypolis_io(io = "write", file_path = paste0(polis_data_folder, "/Core_Ready_Files/afp_empty_coords.csv"),
+  tidypolis_io(io = "write", file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_empty_coords.csv"),
                obj = empty.coord |>
                  dplyr::select(polis.case.id, epid, date.onset, place.admin.0, polis.latitude, polis.longitude))
 
@@ -2884,7 +2884,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   cli::cli_process_start("Checking District GUIDs")
   afp.noshape <- dplyr::anti_join(afp.linelist.fixed.03, global.dist.01, by=c("Admin2GUID"="GUID"))
 
-  tidypolis_io(obj = afp.noshape, io = "write", file_path = paste(polis_data_folder, "/Core_Ready_Files/AFP_epids_bad_guid.csv", sep = ""))
+  tidypolis_io(obj = afp.noshape, io = "write", file_path = paste(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/AFP_epids_bad_guid.csv", sep = ""))
 
   cli::cli_process_done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1169,7 +1169,8 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     dplyr::filter(is.na(polis.latitude) | is.na(polis.longitude) | (polis.latitude == 0 & polis.longitude == 0))
 
   tidypolis_io(io = "write", file_path = paste0(polis_data_folder, "/Core_Ready_Files/afp_empty_coords.csv"),
-               obj = empty.coord)
+               obj = empty.coord |>
+                 dplyr::select(polis.case.id, epid, date.onset, place.admin.0, polis.latitude, polis.longitude))
 
   cli::cli_process_start("Spatially joining AFP cases to global districts")
   #create sf object from lat lon and make global.dist valid
@@ -1206,6 +1207,13 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
   sf_use_s2(T)
 
   cli::cli_process_done()
+
+  #bind back together df02 and df03
+  df04 <- dplyr::bind_rows(df02, df03)
+
+  cli::cli_process_done()
+
+
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1239,6 +1239,18 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
 
   rm(dupes, dupes.01, dupes.02)
 
+  #remove the duplicate cases from df04 and bind back the fixed dupes
+  df05 <- df04 |>
+    dplyr::filter(!epid %in% dupes.fixed$epid) |>
+    dplyr::bind_rows(dupes.fixed)
+
+  #identify dropped obs. obs are dropped primarily because they match to a shape that doesn't
+  #exist for the case's year onset (there are holes in the global map for certain years)
+  df04$geometry <- NULL
+  #antijoin from df01 to keep polis.lat/lon
+  dropped.obs <- dplyr::anti_join(df01, df04, by = "epid") |>
+    dplyr::filter(!epid %in% df04$epid & epid %in% df01.sf$epid)
+
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1180,6 +1180,14 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     sf::st_as_sf(coords = c(x = "lon" , y = "lat"), crs = 4326)
 
   global.dist.02 <- sf::st_make_valid(global.dist.01)
+
+  #identify bad shape rows after make_valid
+  check.dist.2 <- as_tibble(st_is_valid(global.dist.02))
+  row.num.2 <- which(check.dist.2$value == FALSE)
+  #removing all bad shapes post make valid
+  valid.shapes <- global.dist.02 |>
+    dplyr::slice(-row.num.2) |>
+    dplyr::select(GUID, ADM1_GUID, ADM0_GUID, yr.st, yr.end, SHAPE)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1164,106 +1164,13 @@ f.download.compare.02 <- function(df.from.f.download.compare.01, old.download, n
 #' @returns tibble with lat/lon for all unsampled locations
 f.pre.stsample.01 <- function(df01, global.dist.01) {
 
-  df01.noshape <- dplyr::anti_join(df01, global.dist.01, by=c("Admin2GUID"="GUID"))
+  #need to identify cases with no lat/lon
+  empty.coord <- df01 |>
+    dplyr::filter(is.na(polis.latitude) | is.na(polis.longitude) | (polis.latitude == 0 & polis.longitude == 0))
 
-  df01.shape <- dplyr::right_join(global.dist.01, df01 |> dplyr::filter(!is.na(Admin2GUID)), by=c("GUID"="Admin2GUID"))
+  tidypolis_io(io = "write", file_path = paste0(polis_data_folder, "/Core_Ready_Files/afp_empty_coords.csv"),
+               obj = empty.coord)
 
-  df01.shape$empty.01 <- sf::st_is_empty(df01.shape)
-  df01.shape <- dplyr::filter(df01.shape, !empty.01)
-
-  df02.ref <- df01.shape |>
-    tibble::as_tibble() |>
-    dplyr::group_by(GUID) |>
-    dplyr::summarise(nperarm = dplyr::n()) |>
-    dplyr::arrange(GUID) |>
-    dplyr::mutate(id = dplyr::row_number()) |>
-    dplyr::ungroup()
-
-  df02 <- global.dist.01 |>
-    dplyr::select(GUID) |>
-    dplyr::filter(GUID %in% df02.ref$GUID) |>
-    dplyr::left_join(df02.ref, by = "GUID")
-
-  cli::cli_process_start("Placing random points")
- # pt01 <- suppressMessages(sf::st_sample(df02, df02$nperarm,
-  #                                       exact = T, progress = T))
-
-  pt01 <- lapply(1:nrow(df02), function(x){
-
-    tryCatch(
-      expr = {suppressMessages(sf::st_sample(df02[x,], pull(df02[x,], "nperarm"),
-                                            exact = T)) |> st_as_sf()},
-      error = function(e) {
-        guid = df02[x, ]$GUID[1]
-        ctry_prov_dist_name = global.dist.01 |> filter(GUID == guid) |> select(ADM0_NAME, ADM1_NAME, ADM2_NAME)
-        cli::cli_alert_warning(paste0("Fixing errors for:\n",
-                                      "Country: ", ctry_prov_dist_name$ADM0_NAME,"\n",
-                                      "Province: ", ctry_prov_dist_name$ADM1_NAME, "\n",
-                                      "District: ", ctry_prov_dist_name$ADM2_NAME))
-
-        suppressWarnings(
-          {
-          sf_use_s2(F)
-          int <- df02[x,] |> st_centroid(of_largest_polygon = T)
-          sf_use_s2(T)
-
-          st_buffer(int, dist = 3000) |>
-                   st_sample(slice(df02, x) |>
-                               pull(nperarm)) |>
-                   st_as_sf()
-          }
-        )
-
-      }
-    )
-
-  }) |>
-    bind_rows()
-
-  cli::cli_process_done()
-
-  pt01_sf <- pt01
-
-  pt01_joined <- dplyr::bind_cols(
-    pt01_sf,
-    df02 |>
-      tibble::as_tibble() |>
-      dplyr::select(GUID, nperarm) |>
-      tidyr::uncount(nperarm)
-  ) |>
-    dplyr::left_join(tibble::as_tibble(df02) |> dplyr::select(-SHAPE), by = "GUID")
-
-
-
-  #pt01_joined <- sf::st_join(pt01_sf, df02)
-
-  pt01_joined <- dplyr::bind_cols(
-    tibble::as_tibble(pt01_joined),
-    sf::st_coordinates(pt01_joined) |>
-      tibble::as_tibble() |>
-      dplyr::rename("lon" = "X", "lat" = "Y")
-  )
-
-  df03 <- pt01_joined |>
-    tibble::as_tibble() |>
-    dplyr::select(-nperarm, -id) |>
-    dplyr::group_by(GUID)|>
-    dplyr::arrange(GUID, .by_group = TRUE) |>
-    dplyr::mutate(id = dplyr::row_number()) |>
-    as.data.frame()
-
-  df04 <- df01.shape |>
-    dplyr::group_by(GUID)|>
-    dplyr::arrange(GUID, .by_group = TRUE) |>
-    dplyr::mutate(id = dplyr::row_number())
-
-  df05 <- dplyr::full_join(df04, df03, by = c("GUID", "id"))
-
-  sf::st_geometry(df05) <- NULL
-
-  df06 <- dplyr::bind_rows(df05, df01.noshape)
-
-  return(df06)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3353,7 +3353,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
      'not.afp', 'not.afp.01', 'not_afp_metadata_comparison', 'old',
      'old.file', 'old_table_metadata', 'startyr',
      'unknown.afp', 'x', "afp.new", "afp.to.combine", "non.afp.new",
-     "non.afp.to.combine", "afp.noshape"
+     "non.afp.to.combine", "afp.noshape", "guid.check.vars"
   )
 
   gc()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1213,6 +1213,27 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
 
   cli::cli_process_done()
 
+  #df04 has a lot of dupes due to overlapping shapes, need to appropriately de dupe
+  #identify duplicate obs
+  dupes <- df04 |>
+    dplyr::group_by(epid) |>
+    dplyr::mutate(n = n()) |>
+    dplyr::ungroup() |>
+    dplyr::filter(n >1)
+
+  #duplicate obs where adm2guid matches GUID in shapefile
+  dupes.01 <- dupes |>
+    dplyr::filter(Admin2GUID == GUID) |>
+    dplyr::select(-n)
+
+  #duplicate obs where adm2guid is NA or doesn't match to shapefile
+  dupes.02 <- dupes |>
+    dplyr::filter(!epid %in% dupes.01$epid) |>
+    dplyr::group_by(epid) |>
+    dplyr::slice(1) |>
+    dplyr::ungroup() |>
+    dplyr::select(-n) |>
+    dplyr::mutate(Admin2GUID = GUID)
 
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -2866,7 +2866,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
     dplyr::distinct() |>
     dplyr::arrange(epid)
 
-  tidypolis_io(obj = dup.epid, io = "write", file_path = paste(polis_data_folder, "/Core_Ready_Files/", paste("duplicate_AFP_epids_Polis",
+  tidypolis_io(obj = dup.epid, io = "write", file_path = paste(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/", paste("duplicate_AFP_epids_Polis",
                                                                                                               min(dup.epid$yronset, na.rm = T),
                                                                                                               max(dup.epid$yronset, na.rm = T),
                                                                                                               sep = "_"), ".csv", sep = "")


### PR DESCRIPTION
to test pull afp_linelist_2019_2024 from polis_test on EDAV and compare polis.lat/lon to the created lat/lon variables. they should be the exact same with some small rounding differences. you can also check cases with a missing adm2guid and cases with adm2guids that are actually in the unofficial shapes, these cases will have missing lat/lon but retain their original polis.lat/lon.

please test sia rounds first so that I can pre-process a new afp linelist with the additional shape checking 