### PR TITLE
100 pre processing identification of missingness

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1780,6 +1780,16 @@ check_missingness <- function(data,
                 "case.date", "date.onset", "stool.date.sent.to.lab", "clinical.admitted.date",
                 "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
 
+  if(type == "AFP") {
+
+    missing_by_group <- data |>
+      dplyr::select(yronset, place.admin.0, all_of(afp.vars)) |>
+      dplyr::group_by(yronset, place.admin.0) |>
+      summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100)) |>
+      dplyr::ungroup() |>
+      dplyr::filter(dplyr::if_any(afp.vars, ~ . >= 10))
+
+  }
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2598,9 +2598,6 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   gc()
   cli::cli_process_done()
 
-  cli::cli_process_start("Checking for missingness in key variables")
-  cli::cli_process_done("Check   for missing key varialbes")
-
   #Find out if there are duplicate epids.
   cli::cli_process_start("Checking for duplicated EPIDs")
   afp.raw.dup <- afp.raw.new |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -1783,9 +1783,9 @@ check_missingness <- function(data,
                   "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
 
     missing_by_group <- data |>
-      dplyr::select(yronset, place.admin.0, dplyr::all_of(afp.vars)) |>
+      dplyr::select("yronset", "place.admin.0", dplyr::any_of(afp.vars)) |>
       dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("yronset", "place.admin.0")) |>
-      dplyr::filter(dplyr::if_any(afp.vars, ~ . >= 10))
+      dplyr::filter(dplyr::if_any(dplyr::any_of(afp.vars), ~ . >= 10))
 
     tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingness.rds"))
   }
@@ -1797,10 +1797,12 @@ check_missingness <- function(data,
       dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("collect.yr", "admin.0")) |>
       dplyr::filter(who.region >= 10 | collection.date >= 10)
 
-    if(nrow(missing_by_group) > 0) {
+    if (nrow(missing_by_group) > 0) {
       tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/es_missingness.rds"))
     }
   }
+
+  return(missing_by_group)
 }
 
 #### Pre-processing ####

--- a/R/utils.R
+++ b/R/utils.R
@@ -2668,6 +2668,10 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   cli::cli_process_done()
 
+  cli::cli_process_start("Checking for missingness in key variables")
+
+  cli::cli_process_done("Check   for missing key varialbes")
+
   cli::cli_process_start("Classification of cases using lab data")
   # this uses the laboratory data "poliovirustypes" to assign virus type (WPV1 WPV3 and vdpv1,2,2)
   # vtype assigns the polioviruses found in stool excluding sabin

--- a/R/utils.R
+++ b/R/utils.R
@@ -1764,6 +1764,16 @@ run_cluster_dates <- function(data,
   return(out)
 }
 
+
+#' @description
+#' a function to assess key variable missingness
+#'
+#' @import dplyr
+#' @param df tibble the datatable for which we want to check key variable missingness
+#' @param type str "AFP", "ES", or "POS", type of dataset to check missingness
+check_missingness <- function(data,
+                              type) {}
+
 #### Pre-processing ####
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4392,8 +4392,6 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
     cli::cli_alert_info("No previous Virus table identified")
   }
 
-
-
   # Step 5: check virus types and virus type names to ensure that novel derived viruses are properly
   # accounted for
 
@@ -4524,6 +4522,11 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   } else {
     cli::cli_alert_info("If no duplicates found, then proceed")
   }
+
+  tidypolis_io(io = "write", obj = virus.01 |>
+                 dplyr::select(epid, dateonset) |>
+                 dplyr::filter(is.na(dateonset)),
+               file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/virus_missing_onset.csv"))
 
   # Human virus dataset with sabin 2 and positive viruses only
   human.virus.01 <- virus.01 |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -4095,7 +4095,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   remove("es.dup.01")
 
   cli::cli_process_start("Checking for missingness in key ES vars")
-
+  check_missingness(data = es.02, type = "ES")
   cli::cli_process_done("Review missing vars in es_missingness.rds")
 
   cli::cli_process_start("Cleaning 'virus.type' and creating CDC variables")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1789,7 +1789,9 @@ check_missingness <- function(data,
       dplyr::ungroup() |>
       dplyr::filter(dplyr::if_any(afp.vars, ~ . >= 10))
 
+    tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingess.rds"))
   }
+
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1794,9 +1794,18 @@ check_missingness <- function(data,
 
   if(type == "ES"){
 
+    missing_by_group <- data |>
+      dplyr::select(collect.yr, admin.0, who.region, collection.date) |>
+      dplyr::group_by(collect.yr, admin.0) |>
+      summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100)) |>
+      dplyr::ungroup() |>
+      dplyr::filter(who.region >= 10 | collection.date >= 10)
+
+    if(nrow(missing_by_group) > 0) {
+      tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/es_missingess.rds"))
+    }
+
   }
-
-
 }
 
 #### Pre-processing ####

--- a/R/utils.R
+++ b/R/utils.R
@@ -1772,7 +1772,16 @@ run_cluster_dates <- function(data,
 #' @param df tibble the datatable for which we want to check key variable missingness
 #' @param type str "AFP", "ES", or "POS", type of dataset to check missingness
 check_missingness <- function(data,
-                              type) {}
+                              type) {
+
+  afp.vars <- c("notification.date", "investigation.date",
+                "stool.1.collection.date", "stool.2.collection.date",
+                "date.notification.to.hq", "results.seq.date.to.program", "specimen.date",
+                "case.date", "date.onset", "stool.date.sent.to.lab", "clinical.admitted.date",
+                "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
+
+
+}
 
 #### Pre-processing ####
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2700,8 +2700,8 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   cli::cli_process_done()
 
   cli::cli_process_start("Checking for missingness in key variables")
-
-  cli::cli_process_done("Check   for missing key varialbes")
+  check_missingness(afp.raw.01)
+  cli::cli_process_done("Check afp_missingess.rds for missing key varialbes")
 
   cli::cli_process_start("Classification of cases using lab data")
   # this uses the laboratory data "poliovirustypes" to assign virus type (WPV1 WPV3 and vdpv1,2,2)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1784,9 +1784,7 @@ check_missingness <- function(data,
 
     missing_by_group <- data |>
       dplyr::select(yronset, place.admin.0, all_of(afp.vars)) |>
-      dplyr::group_by(yronset, place.admin.0) |>
-      summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100)) |>
-      dplyr::ungroup() |>
+      dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("yronset", "place.admin.0")) |>
       dplyr::filter(dplyr::if_any(afp.vars, ~ . >= 10))
 
     tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingess.rds"))
@@ -1796,15 +1794,12 @@ check_missingness <- function(data,
 
     missing_by_group <- data |>
       dplyr::select(collect.yr, admin.0, who.region, collection.date) |>
-      dplyr::group_by(collect.yr, admin.0) |>
-      summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100)) |>
-      dplyr::ungroup() |>
+      dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("collect.yr", "admin.0")) |>
       dplyr::filter(who.region >= 10 | collection.date >= 10)
 
     if(nrow(missing_by_group) > 0) {
       tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/es_missingess.rds"))
     }
-
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2598,6 +2598,9 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   gc()
   cli::cli_process_done()
 
+  cli::cli_process_start("Checking for missingness in key variables")
+  cli::cli_process_done("Check   for missing key varialbes")
+
   #Find out if there are duplicate epids.
   cli::cli_process_start("Checking for duplicated EPIDs")
   afp.raw.dup <- afp.raw.new |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -2699,6 +2699,12 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   cli::cli_process_done()
 
+  #write out epids with no dateonset
+  tidypolis_io(io = "write", obj = afp.raw.01 |>
+                 dplyr::select(epid, dateonset) |>
+                 dplyr::filter(is.na(dateonset)),
+               file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_no_onset.csv"))
+
   cli::cli_process_start("Checking for missingness in key variables")
   check_missingness(afp.raw.01)
   cli::cli_process_done("Check afp_missingess.rds for missing key varialbes")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1792,6 +1792,10 @@ check_missingness <- function(data,
     tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingess.rds"))
   }
 
+  if(type == "ES"){
+
+  }
+
 
 }
 
@@ -2706,7 +2710,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
                file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_no_onset.csv"))
 
   cli::cli_process_start("Checking for missingness in key variables")
-  check_missingness(afp.raw.01)
+  check_missingness(data = afp.raw.01, type = "AFP")
   cli::cli_process_done("Check afp_missingess.rds for missing key varialbes")
 
   cli::cli_process_start("Classification of cases using lab data")
@@ -4082,6 +4086,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
   remove("es.dup.01")
 
   cli::cli_process_start("Checking for missingness in key ES vars")
+
   cli::cli_process_done("Review missing vars in es_missingness.rds")
 
   cli::cli_process_start("Cleaning 'virus.type' and creating CDC variables")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1774,13 +1774,13 @@ run_cluster_dates <- function(data,
 check_missingness <- function(data,
                               type) {
 
-  afp.vars <- c("notification.date", "investigation.date",
-                "stool.1.collection.date", "stool.2.collection.date",
-                "date.notification.to.hq", "results.seq.date.to.program", "specimen.date",
-                "case.date", "date.onset", "stool.date.sent.to.lab", "clinical.admitted.date",
-                "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
-
   if(type == "AFP") {
+
+    afp.vars <- c("notification.date", "investigation.date",
+                  "stool.1.collection.date", "stool.2.collection.date",
+                  "date.notification.to.hq", "results.seq.date.to.program", "specimen.date",
+                  "case.date", "date.onset", "stool.date.sent.to.lab", "clinical.admitted.date",
+                  "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
 
     missing_by_group <- data |>
       dplyr::select(yronset, place.admin.0, all_of(afp.vars)) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -1774,7 +1774,7 @@ run_cluster_dates <- function(data,
 check_missingness <- function(data,
                               type) {
 
-  if(type == "AFP") {
+  if (type == "AFP") {
 
     afp.vars <- c("notification.date", "investigation.date",
                   "stool.1.collection.date", "stool.2.collection.date",
@@ -1783,14 +1783,14 @@ check_missingness <- function(data,
                   "followup.date", "stool.1.condition", "stool.2.condition", "age.months")
 
     missing_by_group <- data |>
-      dplyr::select(yronset, place.admin.0, all_of(afp.vars)) |>
+      dplyr::select(yronset, place.admin.0, dplyr::all_of(afp.vars)) |>
       dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("yronset", "place.admin.0")) |>
       dplyr::filter(dplyr::if_any(afp.vars, ~ . >= 10))
 
-    tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingess.rds"))
+    tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/afp_missingness.rds"))
   }
 
-  if(type == "ES"){
+  if (type == "ES") {
 
     missing_by_group <- data |>
       dplyr::select(collect.yr, admin.0, who.region, collection.date) |>
@@ -1798,7 +1798,7 @@ check_missingness <- function(data,
       dplyr::filter(who.region >= 10 | collection.date >= 10)
 
     if(nrow(missing_by_group) > 0) {
-      tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/es_missingess.rds"))
+      tidypolis_io(io = "write", obj = missing_by_group, file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/Core_Ready_Files/es_missingness.rds"))
     }
   }
 }
@@ -2715,7 +2715,7 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   cli::cli_process_start("Checking for missingness in key variables")
   check_missingness(data = afp.raw.01, type = "AFP")
-  cli::cli_process_done("Check afp_missingess.rds for missing key varialbes")
+  cli::cli_process_done("Check afp_missingness.rds for missing key variables")
 
   cli::cli_process_start("Classification of cases using lab data")
   # this uses the laboratory data "poliovirustypes" to assign virus type (WPV1 WPV3 and vdpv1,2,2)

--- a/R/utils.R
+++ b/R/utils.R
@@ -4075,6 +4075,9 @@ preprocess_cdc <- function(polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")) {
 
   remove("es.dup.01")
 
+  cli::cli_process_start("Checking for missingness in key ES vars")
+  cli::cli_process_done("Review missing vars in es_missingness.rds")
+
   cli::cli_process_start("Cleaning 'virus.type' and creating CDC variables")
 
   es.space.02 <- es.02 |>


### PR DESCRIPTION
to test you can simply check the afp_missingness.rds in polis_test on EDAV. this dataset summarizes the percentage of missingness by "key variables" -> variables used in various analysis functions on used to create other analysis variables, grouped by country and year.

the idea would be that this rds will allow users to quickly check the quality/limitations of afp data before running analysis

Included in this pull request are also outputs for cases missing date of onset 