### PR TITLE
148 update shapefile preprocessing function for shape names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -3959,7 +3959,7 @@ process_spatial <- function(gdb_folder,
     }
   }
 
-  rm(dupe.guid.ctry, dupe.name.ctry)
+  rm(dupe.guid.ctry, dupe.name.ctry, sf_columns_ctry, sf_var_ctry)
 
   #ensure CRS of ctry file is 4326
   global.ctry.01 <- sf::st_set_crs(global.ctry.01, 4326)

--- a/R/utils.R
+++ b/R/utils.R
@@ -3897,7 +3897,7 @@ process_spatial <- function(gdb_folder,
   }
 
   empty.ctry <- global.ctry.01 |>
-    dplyr::mutate(empty = sf::st_is_empty(Shape)) |>
+    dplyr::mutate(empty = sf::st_is_empty(!!dplyr::sym(sf_var_ctry))) |>
     dplyr::filter(empty == TRUE)
 
   sf::st_geometry(empty.ctry) <- NULL
@@ -4007,7 +4007,7 @@ process_spatial <- function(gdb_folder,
   }
 
   empty.prov <- global.prov.01 |>
-    dplyr::mutate(empty = sf::st_is_empty(Shape)) |>
+    dplyr::mutate(empty = sf::st_is_empty(!!dplyr::sym(sf_var_prov))) |>
     dplyr::filter(empty == TRUE)
 
   if(nrow(empty.prov) > 0) {
@@ -4110,7 +4110,7 @@ process_spatial <- function(gdb_folder,
   }
 
   empty.dist <- global.dist.01 |>
-    dplyr::mutate(empty = sf::st_is_empty(Shape)) |>
+    dplyr::mutate(empty = sf::st_is_empty(!!dplyr::sym(sf_var_dist))) |>
     dplyr::filter(empty == TRUE)
 
   if(nrow(empty.dist) > 0) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -3871,12 +3871,17 @@ process_spatial <- function(gdb_folder,
 
   }
 
+  #identify sf var in global.ctry
+  sf_columns_ctry <- sapply(global.ctry.01, function(col) inherits(col, "sfc"))
+
+  sf_var_ctry <- names(global.ctry.01)[sf_columns]
+
   #identifying bad shapes
   check.ctry.valid <- tibble::as_tibble(sf::st_is_valid(global.ctry.01))
   row.num.ctry <- which(check.ctry.valid$value == FALSE)
   invalid.ctry.shapes <- global.ctry.01 |>
     dplyr::slice(row.num.ctry) |>
-    dplyr::select(ADM0_NAME, GUID, yr.st, yr.end, Shape) |>
+    dplyr::select(ADM0_NAME, GUID, yr.st, yr.end, paste(sf_var_ctry)) |>
     dplyr::arrange(ADM0_NAME)
 
   sf::st_geometry(invalid.ctry.shapes) <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -3808,7 +3808,7 @@ process_spatial <- function(gdb_folder,
     output_folder <- stringr::str_replace(output_folder, paste0("GID/PEB/SIR/"), "")
   }
 
-  if(edav) {
+  if (edav) {
     dest <- tempdir()
     AzureStor::storage_download(container = azcontainer, gdb_folder, paste0(dest, "/gdb.zip"), overwrite = T)
 
@@ -3887,14 +3887,14 @@ process_spatial <- function(gdb_folder,
 
   sf::st_geometry(invalid.ctry.shapes) <- NULL
 
-  if(edav) {
+  if (edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/invalid_ctry_shapes.csv"),
-                 obj = invalid.ctry.shapes)
+                 obj = invalid.ctry.shapes, azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/invalid_ctry_shapes.csv"),
-                 obj = invalid.ctry.shapes)
+                 obj = invalid.ctry.shapes, azcontainer = azcontainer)
   }
 
   empty.ctry <- global.ctry.01 |>
@@ -3904,14 +3904,16 @@ process_spatial <- function(gdb_folder,
   sf::st_geometry(empty.ctry) <- NULL
 
   if(nrow(empty.ctry) > 0) {
-    if(edav) {
+    if (edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/empty_ctry_shapes.csv"),
-                   obj = empty.ctry)
+                   obj = empty.ctry,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/empty_ctry_shapes.csv"),
-                   obj = empty.ctry)
+                   obj = empty.ctry,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -3920,13 +3922,13 @@ process_spatial <- function(gdb_folder,
   #identify potential duplicates
   dupe.guid.ctry <- global.ctry.01 |>
     dplyr::group_by(GUID) |>
-    dplyr::mutate(n = n()) |>
+    dplyr::mutate(n = dplyr::n()) |>
     dplyr::ungroup() |>
     dplyr::filter(n > 1)
 
   dupe.name.ctry <- global.ctry.01 |>
     dplyr::group_by(ADM0_NAME, yr.st, yr.end) |>
-    dplyr::mutate(n = n()) |>
+    dplyr::mutate(n = dplyr::n()) |>
     dplyr::ungroup() |>
     dplyr::filter(n > 1)
 
@@ -3939,11 +3941,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_ctry_guid.csv"),
-                   obj = dupe.guid.ctry)
+                   obj = dupe.guid.ctry,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_ctry_guid.csv"),
-                   obj = dupe.guid.ctry)
+                   obj = dupe.guid.ctry,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -3952,11 +3956,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_ctry_name.csv"),
-                   obj = dupe.name.ctry)
+                   obj = dupe.name.ctry,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_ctry_name.csv"),
-                   obj = dupe.name.ctry)
+                   obj = dupe.name.ctry,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -3969,11 +3975,13 @@ process_spatial <- function(gdb_folder,
   if(edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/global.ctry.rds"),
-                 obj = global.ctry.01)
+                 obj = global.ctry.01,
+                 azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/global.ctry.rds"),
-                 obj = global.ctry.01)
+                 obj = global.ctry.01,
+                 azcontainer = azcontainer)
   }
 
   sf::st_geometry(global.ctry.01) <- NULL
@@ -4000,11 +4008,13 @@ process_spatial <- function(gdb_folder,
   if(edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/invalid_prov_shapes.csv"),
-                 obj = invalid.prov.shapes)
+                 obj = invalid.prov.shapes,
+                 azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/invalid_prov_shapes.csv"),
-                 obj = invalid.prov.shapes)
+                 obj = invalid.prov.shapes,
+                 azcontainer = azcontainer)
   }
 
   empty.prov <- global.prov.01 |>
@@ -4048,11 +4058,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_prov_guid.csv"),
-                   obj = dupe.guid.prov)
+                   obj = dupe.guid.prov,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_prov_guid.csv"),
-                   obj = dupe.guid.prov)
+                   obj = dupe.guid.prov,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4061,11 +4073,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_prov_name.csv"),
-                   obj = dupe.name.prov)
+                   obj = dupe.name.prov,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_prov_name.csv"),
-                   obj = dupe.name.prov)
+                   obj = dupe.name.prov,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4077,11 +4091,13 @@ process_spatial <- function(gdb_folder,
   if(edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/global.prov.rds"),
-                 obj = global.prov.01)
+                 obj = global.prov.01,
+                 azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/global.prov.rds"),
-                 obj = global.prov.01)
+                 obj = global.prov.01,
+                 azcontainer = azcontainer)
   }
 
   sf::st_geometry(global.prov.01) <- NULL
@@ -4103,11 +4119,13 @@ process_spatial <- function(gdb_folder,
   if(edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/invalid_dist_shapes.csv"),
-                 obj = invalid.dist.shapes)
+                 obj = invalid.dist.shapes,
+                 azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/invalid_dist_shapes.csv"),
-                 obj = invalid.dist.shapes)
+                 obj = invalid.dist.shapes,
+                 azcontainer = azcontainer)
   }
 
   empty.dist <- global.dist.01 |>
@@ -4119,11 +4137,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/empty_dist_shapes.csv"),
-                   obj = empty.dist)
+                   obj = empty.dist,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/empty_dist_shapes.csv"),
-                   obj = empty.dist)
+                   obj = empty.dist,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4152,11 +4172,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_dist_guid.csv"),
-                   obj = dupe.guid.dist)
+                   obj = dupe.guid.dist,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_dist_guid.csv"),
-                   obj = dupe.guid.dist)
+                   obj = dupe.guid.dist,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4165,11 +4187,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_dist_name.csv"),
-                   obj = dupe.name.dist)
+                   obj = dupe.name.dist,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/duplicate_dist_name.csv"),
-                   obj = dupe.name.dist)
+                   obj = dupe.name.dist,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4181,11 +4205,13 @@ process_spatial <- function(gdb_folder,
   if(edav) {
     tidypolis_io(io = "write", edav = T,
                  file_path = paste0(output_folder, "/global.dist.rds"),
-                 obj = global.dist.01)
+                 obj = global.dist.01,
+                 azcontainer = azcontainer)
   } else {
     tidypolis_io(io = "write", edav = F,
                  file_path = paste0(output_folder, "/global.dist.rds"),
-                 obj = global.dist.01)
+                 obj = global.dist.01,
+                 azcontainer = azcontainer)
   }
 
   sf::st_geometry(global.dist.01) <- NULL
@@ -4217,14 +4243,16 @@ process_spatial <- function(gdb_folder,
                                       paste(min(prov.shape.issue.01$active.year.01, na.rm = T),
                                             max(prov.shape.issue.01$active.year.01, na.rm = T),
                                             sep = "_"), ".csv"),
-                   obj = prov.shape.issue.01)
+                   obj = prov.shape.issue.01,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/prov_shape_multiple_",
                                       paste(min(prov.shape.issue.01$active.year.01, na.rm = T),
                                             max(prov.shape.issue.01$active.year.01, na.rm = T),
                                             sep = "_"), ".csv"),
-                   obj = prov.shape.issue.01)
+                   obj = prov.shape.issue.01,
+                   azcontainer = azcontainer)
     }
   }
 
@@ -4252,14 +4280,16 @@ process_spatial <- function(gdb_folder,
                                       paste(min(dist.shape.issue.01$active.year.01, na.rm = T),
                                             max(dist.shape.issue.01$active.year.01, na.rm = T),
                                             sep = "_"), ".csv"),
-                   obj = dist.shape.issue.01)
+                   obj = dist.shape.issue.01,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/dist_shape_multiple_",
                                       paste(min(dist.shape.issue.01$active.year.01, na.rm = T),
                                             max(dist.shape.issue.01$active.year.01, na.rm = T),
                                             sep = "_"), ".csv"),
-                   obj = dist.shape.issue.01)
+                   obj = dist.shape.issue.01,
+                   azcontainer = azcontainer)
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3793,6 +3793,15 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER")) {
 #' @param edav `bool` Whether gdb is on EDAV or local.
 #' @param azcontainer `Azure container` Azure storage container.
 #' @export
+#' @examples
+#' \dontrun{
+#' process_spatial(gdb_folder = "local_path/GEODATABASE.gdb",
+#' output_folder = "local_path",
+#' edav = F)
+#' process_spatial(gdb_folder = "edav_path/GEODATABASE.gdb",
+#' output_folder = "edav_path",
+#' edav = T)
+#' }
 process_spatial <- function(gdb_folder,
                             output_folder,
                             edav,

--- a/R/utils.R
+++ b/R/utils.R
@@ -4140,10 +4140,12 @@ process_spatial <- function(gdb_folder,
   cli::cli_process_done()
 
   #identify sf var in global.dist
+  cli::cli_process_start("District shape processing")
   sf_columns_dist <- sapply(global.dist.01, function(col) inherits(col, "sfc"))
 
   sf_var_dist <- names(global.dist.01)[sf_columns_dist]
 
+  cli::cli_process_start("Checking district shape validity")
   check.dist.valid <- tibble::as_tibble(sf::st_is_valid(global.dist.01))
   row.num.dist <- which(check.dist.valid$value == FALSE)
   invalid.dist.shapes <- global.dist.01 |>
@@ -4164,12 +4166,14 @@ process_spatial <- function(gdb_folder,
                  obj = invalid.dist.shapes,
                  azcontainer = azcontainer)
   }
+  cli::cli_process_done()
 
   empty.dist <- global.dist.01 |>
     dplyr::mutate(empty = sf::st_is_empty(!!dplyr::sym(sf_var_dist))) |>
     dplyr::filter(empty == TRUE)
 
   if(nrow(empty.dist) > 0) {
+    cli::cli_process_start("Outputting empty district shapes")
     sf::st_geometry(empty.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
@@ -4182,11 +4186,13 @@ process_spatial <- function(gdb_folder,
                    obj = empty.dist,
                    azcontainer = azcontainer)
     }
+    cli::cli_process_done
   }
 
   rm(check.dist.valid, row.num.dist, invalid.dist.shapes, empty.dist)
 
   #evaluate district duplicates
+  cli::cli_process_start("Checking district shapes for duplicates")
   dupe.guid.dist <- global.dist.01 |>
     dplyr::group_by(GUID) |>
     dplyr::mutate(n = n()) |>
@@ -4205,6 +4211,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.guid.dist) > 1) {
+    cli::cli_process_start("Outputting districts with duplicate GUIDs")
     sf::st_geometry(dupe.guid.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
@@ -4217,9 +4224,11 @@ process_spatial <- function(gdb_folder,
                    obj = dupe.guid.dist,
                    azcontainer = azcontainer)
     }
+    cli::cli_process_done()
   }
 
   if(nrow(dupe.name.dist) > 1) {
+    cli::cli_process_start("Outputting districts with duplicate names")
     sf::st_geometry(dupe.name.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
@@ -4232,8 +4241,10 @@ process_spatial <- function(gdb_folder,
                    obj = dupe.name.dist,
                    azcontainer = azcontainer)
     }
+    cli::cli_process_done()
   }
 
+  cli::cli_process_done()
   rm(dupe.guid.dist, dupe.name.dist, sf_columns_dist, sf_var_dist)
 
   #ensure district CRS is 4326
@@ -4250,6 +4261,8 @@ process_spatial <- function(gdb_folder,
                  obj = global.dist.01,
                  azcontainer = azcontainer)
   }
+
+  cli::cli_process_done()
 
   sf::st_geometry(global.dist.01) <- NULL
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4085,11 +4085,16 @@ process_spatial <- function(gdb_folder,
 
   sf::st_geometry(global.prov.01) <- NULL
 
+  #identify sf var in global.dist
+  sf_columns_dist <- sapply(global.dist.01, function(col) inherits(col, "sfc"))
+
+  sf_var_dist <- names(global.dist.01)[sf_columns_dist]
+
   check.dist.valid <- tibble::as_tibble(sf::st_is_valid(global.dist.01))
   row.num.dist <- which(check.dist.valid$value == FALSE)
   invalid.dist.shapes <- global.dist.01 |>
     dplyr::slice(row.num.dist) |>
-    dplyr::select(ADM0_NAME, ADM1_NAME, ADM2_NAME, GUID, yr.st, yr.end, Shape) |>
+    dplyr::select(ADM0_NAME, ADM1_NAME, ADM2_NAME, GUID, yr.st, yr.end, paste(sf_var_dist)) |>
     dplyr::arrange(ADM0_NAME)
 
   sf::st_geometry(invalid.dist.shapes) <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -3787,14 +3787,16 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER")) {
 #' @description
 #' a function to process WHO spatial datasets
 #' @import dplyr sf lubridate stringr readr tibble cli
-#' @param gdb_folder str the folder location of spatial datasets, should end with .gdb,
-#' if on edav the gdb will need to be zipped, ensure that the gdb and the zipped file name are the same
-#' @param output_folder str folder location to write outputs to
-#' @param edav boolean T or F, whether gdb is on EDAV or local
+#' @param gdb_folder `str` The folder location of spatial datasets, should end with .gdb,
+#' if on edav the gdb will need to be zipped, ensure that the gdb and the zipped file name are the same.
+#' @param output_folder `str` Folder location to write outputs to.
+#' @param edav `bool` Whether gdb is on EDAV or local.
+#' @param azcontainer `Azure container` Azure storage container.
 #' @export
 process_spatial <- function(gdb_folder,
                             output_folder,
-                            edav) {
+                            edav,
+                            azcontainer = suppressMessages(sirfunctions::get_azure_storage_connection())) {
 
   if (!requireNamespace("utils", quietly = TRUE)) {
     stop('Package "utils" must be installed to use this function.',
@@ -3807,7 +3809,6 @@ process_spatial <- function(gdb_folder,
   }
 
   if(edav) {
-    azcontainer = suppressMessages(get_azure_storage_connection())
     dest <- tempdir()
     AzureStor::storage_download(container = azcontainer, gdb_folder, paste0(dest, "/gdb.zip"), overwrite = T)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3875,7 +3875,7 @@ process_spatial <- function(gdb_folder,
   cli::cli_process_done()
 
   #identify sf var in global.ctry
-  cli::cli_process_start("Starting Country shapefile processing")
+  cli::cli_process_start("Country shapefile processing")
   sf_columns_ctry <- sapply(global.ctry.01, function(col) inherits(col, "sfc"))
 
   sf_var_ctry <- names(global.ctry.01)[sf_columns_ctry]
@@ -4006,7 +4006,7 @@ process_spatial <- function(gdb_folder,
   cli::cli_process_done()
 
   # Province shapes overlapping in Lower Juba in Somalia.
-  cli::cli_process_start("Starting Province shapefile processing")
+  cli::cli_process_start("Province shapefile processing")
   global.prov.01 <- global.prov.01 |>
     dplyr::mutate(yr.end = ifelse(ADM0_GUID == '{B5FF48B9-7282-445C-8CD2-BEFCE4E0BDA7}' &
                                     GUID == '{EE73F3EA-DD35-480F-8FEA-5904274087C4}', 2021, yr.end))

--- a/R/utils.R
+++ b/R/utils.R
@@ -3934,7 +3934,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.guid.ctry) > 1) {
-    dupe.guid.ctry$Shape <- NULL
+    sf::st_geometry(dupe.guid.ctry) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_ctry_guid.csv"),
@@ -3947,7 +3947,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.name.ctry) > 1) {
-    dupe.name.ctry$Shape <- NULL
+    sf::st_geometry(dupe.name.ctry) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_ctry_name.csv"),
@@ -3991,7 +3991,7 @@ process_spatial <- function(gdb_folder,
   row.num.prov <- which(check.prov.valid$value == FALSE)
   invalid.prov.shapes <- global.prov.01 |>
     dplyr::slice(row.num.prov) |>
-    dplyr::select(ADM0_NAME, ADM1_NAME, GUID, yr.st, yr.end, Shape) |>
+    dplyr::select(ADM0_NAME, ADM1_NAME, GUID, yr.st, yr.end, paste(sf_var_prov)) |>
     dplyr::arrange(ADM0_NAME)
 
   sf::st_geometry(invalid.prov.shapes) <- NULL
@@ -4011,6 +4011,7 @@ process_spatial <- function(gdb_folder,
     dplyr::filter(empty == TRUE)
 
   if(nrow(empty.prov) > 0) {
+    sf::st_geometry(empty.prov) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/empty_prov_shapes.csv"),
@@ -4042,7 +4043,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.guid.prov) > 1) {
-    dupe.guid.prov$Shape <- NULL
+    sf::st_geometry(dupe.guid.prov) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_prov_guid.csv"),
@@ -4055,7 +4056,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.name.prov) > 1) {
-    dupe.name.prov$Shape <- NULL
+    sf::st_geometry(dupe.name.prov) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_prov_name.csv"),
@@ -4067,7 +4068,7 @@ process_spatial <- function(gdb_folder,
     }
   }
 
-  rm(dupe.guid.prov, dupe.name.prov)
+  rm(dupe.guid.prov, dupe.name.prov, sf_columns_prov, sf_var_prov)
 
   #ensure CRS is 4326
   global.prov.01 <- sf::st_set_crs(global.prov.01, 4326)

--- a/R/utils.R
+++ b/R/utils.R
@@ -3982,6 +3982,11 @@ process_spatial <- function(gdb_folder,
     dplyr::mutate(yr.end = ifelse(ADM0_GUID == '{B5FF48B9-7282-445C-8CD2-BEFCE4E0BDA7}' &
                                     GUID == '{EE73F3EA-DD35-480F-8FEA-5904274087C4}', 2021, yr.end))
 
+  #identify sf var in global.prov
+  sf_columns_prov <- sapply(global.prov.01, function(col) inherits(col, "sfc"))
+
+  sf_var_prov <- names(global.prov.01)[sf_columns_prov]
+
   check.prov.valid <- tibble::as_tibble(sf::st_is_valid(global.prov.01))
   row.num.prov <- which(check.prov.valid$value == FALSE)
   invalid.prov.shapes <- global.prov.01 |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -4114,6 +4114,7 @@ process_spatial <- function(gdb_folder,
     dplyr::filter(empty == TRUE)
 
   if(nrow(empty.dist) > 0) {
+    sf::st_geometry(empty.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/empty_dist_shapes.csv"),
@@ -4146,7 +4147,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.guid.dist) > 1) {
-    dupe.guid.dist$Shape <- NULL
+    sf::st_geometry(dupe.guid.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_dist_guid.csv"),
@@ -4159,7 +4160,7 @@ process_spatial <- function(gdb_folder,
   }
 
   if(nrow(dupe.name.dist) > 1) {
-    dupe.name.dist$Shape <- NULL
+    sf::st_geometry(dupe.name.dist) <- NULL
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/duplicate_dist_name.csv"),
@@ -4170,6 +4171,8 @@ process_spatial <- function(gdb_folder,
                    obj = dupe.name.dist)
     }
   }
+
+  rm(dupe.guid.dist, dupe.name.dist, sf_columns_dist, sf_var_dist)
 
   #ensure district CRS is 4326
   global.dist.01 <- sf::st_set_crs(global.dist.01, 4326)

--- a/R/utils.R
+++ b/R/utils.R
@@ -4280,6 +4280,7 @@ process_spatial <- function(gdb_folder,
   }
 
   long.global.prov.01 <- do.call(rbind, df.list)
+  cli::cli_process_start("Evaluating overlapping province shapes")
 
   if(endyr == lubridate::year(format(Sys.time())) & startyr == 2000) {
     prov.shape.issue.01 <- long.global.prov.01 |>
@@ -4306,6 +4307,8 @@ process_spatial <- function(gdb_folder,
     }
   }
 
+  cli::cli_process_done()
+
   # District long shape
 
   df.list <- list()
@@ -4317,6 +4320,8 @@ process_spatial <- function(gdb_folder,
   }
 
   long.global.dist.01 <- do.call(rbind, df.list)
+
+  cli::cli_process_start("Evaluating overlapping district shapes")
 
   if(endyr == year(format(Sys.time())) & startyr == 2000) {
     dist.shape.issue.01 <- long.global.dist.01 |>
@@ -4343,6 +4348,7 @@ process_spatial <- function(gdb_folder,
     }
   }
 
+  cli::cli_process_done()
   remove(df.list, df02)
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3874,7 +3874,7 @@ process_spatial <- function(gdb_folder,
   #identify sf var in global.ctry
   sf_columns_ctry <- sapply(global.ctry.01, function(col) inherits(col, "sfc"))
 
-  sf_var_ctry <- names(global.ctry.01)[sf_columns]
+  sf_var_ctry <- names(global.ctry.01)[sf_columns_ctry]
 
   #identifying bad shapes
   check.ctry.valid <- tibble::as_tibble(sf::st_is_valid(global.ctry.01))

--- a/R/utils.R
+++ b/R/utils.R
@@ -4026,11 +4026,13 @@ process_spatial <- function(gdb_folder,
     if(edav) {
       tidypolis_io(io = "write", edav = T,
                    file_path = paste0(output_folder, "/empty_prov_shapes.csv"),
-                   obj = empty.prov)
+                   obj = empty.prov,
+                   azcontainer = azcontainer)
     } else {
       tidypolis_io(io = "write", edav = F,
                    file_path = paste0(output_folder, "/empty_prov_shapes.csv"),
-                   obj = empty.prov)
+                   obj = empty.prov,
+                   azcontainer = azcontainer)
     }
   }
 

--- a/man/process_spatial.Rd
+++ b/man/process_spatial.Rd
@@ -5,15 +5,22 @@
 \title{Process WHO spatial data and output country, province and district level shape files and basic
 quality checks}
 \usage{
-process_spatial(gdb_folder, output_folder, edav)
+process_spatial(
+  gdb_folder,
+  output_folder,
+  edav,
+  azcontainer = suppressMessages(sirfunctions::get_azure_storage_connection())
+)
 }
 \arguments{
-\item{gdb_folder}{str the folder location of spatial datasets, should end with .gdb,
-if on edav the gdb will need to be zipped, ensure that the gdb and the zipped file name are the same}
+\item{gdb_folder}{\code{str} The folder location of spatial datasets, should end with .gdb,
+if on edav the gdb will need to be zipped, ensure that the gdb and the zipped file name are the same.}
 
-\item{output_folder}{str folder location to write outputs to}
+\item{output_folder}{\code{str} Folder location to write outputs to.}
 
-\item{edav}{boolean T or F, whether gdb is on EDAV or local}
+\item{edav}{\code{bool} Whether gdb is on EDAV or local.}
+
+\item{azcontainer}{\verb{Azure container} Azure storage container.}
 }
 \description{
 a function to process WHO spatial datasets


### PR DESCRIPTION
PR updates process_spatial to include dynamic references to sf vars in WHO shapefiles, prevents function breaking if new gdb changes "Shape" to "SHAPE" 

simplest way to test is to grab WHO_POLIO_GLOBAL_GEODATABASE.gdb from the spatial folder on EDAV bring onto local and run from there. it should re-produce all .rds and .csv at GID/PEB/SIR/Data/spatial/ excluding cities and roads