### PR TITLE
184 s2 standardize dates changes var names for date variables needed downstream

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -7015,7 +7015,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         file_path = paste0(
           polis_data_folder,
           "/Core_Ready_Files/",
-          "afp_linelist_light_",
+          "afp_linelist_",
           min(afp_light$dateonset, na.rm = TRUE),
           "_",
           max(afp_light$dateonset, na.rm = TRUE),

--- a/R/utils.R
+++ b/R/utils.R
@@ -5845,7 +5845,12 @@ s2_standardize_dates <- function(data) {
         )),
         ~ lubridate::ymd(as.Date(., "%Y-%m-%dT%H:%M:%S"), quiet = TRUE)
       )
-    )
+    ) |>
+    dplyr::mutate(datenotificationtohq = date.notification.to.hq,
+                  casedate = case.date,
+                  stooltolabdate = stool.date.sent.to.lab,
+                  stooltoiclabdate = stool.date.sent.to.ic.lab,
+                  clinicadmitdate = clinical.admitted.date)
 
   cli::cli_process_done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -7110,9 +7110,9 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
             polis_data_folder,
             "/Core_Ready_Files/",
             "other_surveillance_type_linelist_",
-            min(other_combined$dateonset, na.rm = TRUE),
+            min(other_combined$yronset, na.rm = TRUE),
             "_",
-            max(other_combined$dateonset, na.rm = TRUE),
+            max(other_combined$yronset, na.rm = TRUE),
             ".rds"
           )
         )
@@ -7131,6 +7131,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
   gc(full = TRUE)
 
   invisible(NULL)
+  }
 }
 
 #' Compare AFP data with archived version
@@ -7303,4 +7304,3 @@ s2_compare_with_archive <- function(data,
     modified_details = modified_details
   ))
 }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -7059,6 +7059,64 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
       )
     ))
 
+    # Create combined AFP dataset from multiple files
+    cli::cli_process_start("Generating combined Other Surveillance dataset",
+                           msg_done = "Generated combined Other Surveillance dataset")
+
+    # Find all other surveillance files in Core_Ready_Files and core_files_to_combine
+    other_files_main <- dplyr::tibble("name" = tidypolis_io(
+      io = "list",
+      file_path = paste0(polis_data_folder, "/Core_Ready_Files"),
+      full_names = TRUE
+    )) |>
+      dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
+      dplyr::pull(name)
+
+    other_files_combine <- dplyr::tibble("name" = tidypolis_io(
+      io = "list",
+      file_path = paste0(polis_data_folder, "/core_files_to_combine"),
+      full_names = TRUE
+    )) |>
+      dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
+      dplyr::pull(name)
+
+    # Combine other surveillance files
+    if (length(other_files_combine) > 0) {
+      other_to_combine <- purrr::map_df(other_files_combine, ~ tidypolis_io(
+        io = "read",
+        file_path = .x
+      )) |>
+        dplyr::mutate(
+          stool1tostool2 = as.numeric(stool1tostool2),
+          datenotificationtohq = lubridate::parse_date_time(
+            datenotificationtohq,
+            c("dmY", "bY", "Ymd", "%Y-%m-%d %H:%M:%S")
+          )
+        )
+
+      other_new <- purrr::map_df(
+        other_files_main,
+        ~ tidypolis_io(io = "read", file_path = .x)
+      )
+
+      other_combined <- dplyr::bind_rows(other_new, other_to_combine)
+
+      # Export combined other surveillance dataset
+      invisible(capture.output(
+        tidypolis_io(
+          obj = other_combined,
+          io = "write",
+          file_path = paste0(
+            polis_data_folder,
+            "/Core_Ready_Files/",
+            "other_surveillance_type_linelist_",
+            min(other_combined$dateonset, na.rm = TRUE),
+            "_",
+            max(other_combined$dateonset, na.rm = TRUE),
+            ".rds"
+          )
+        )
+      ))
 
     cli::cli_process_done()
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -5843,8 +5843,7 @@ s2_standardize_dates <- function(data) {
           "case.date", "stool.date.sent.to.lab",
           "clinical.admitted.date", "followup.date"
         )),
-        ~ lubridate::ymd(as.Date(., "%Y-%m-%dT%H:%M:%S"), quiet = TRUE),
-        .names = "date_{stringr::str_replace_all(.col, '[^a-z0-9]', '_')}"
+        ~ lubridate::ymd(as.Date(., "%Y-%m-%dT%H:%M:%S"), quiet = TRUE)
       )
     )
 
@@ -7008,7 +7007,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     # Create light AFP dataset for WHO (filtered to recent years)
     afp_light <- afp_combined |>
       dplyr::filter(yronset >= 2019)
-    
+
     invisible(capture.output(
       tidypolis_io(
         obj = afp_light,


### PR DESCRIPTION
This PR fixes bugs in step 2 ensuring that pre-processing output remains constant. to test you can run pre-processing on POLIS_test on EDAV or locally. or you can review output in POLIS/data/Core_Ready_Files

- AFP data should have same var names as AFP data in first archive folder
- there should be 3 afp linelists in core_ready_files, afp_linelist_2001, _2020 and _2019 without "light" in the name
- there should be 2 other_surveillance_type_linelists, 2016- and 2020-
- ensure epid: AFG/08/25/358 has a matching report_date and datenotificationtohq in the positives file
