### PR TITLE
remove shape vars in step 3 processing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -7254,6 +7254,8 @@ s3_sia_check_guids <- function(sia.02, long.global.dist.01){
     #flag if spatial files do not match
     dplyr::mutate(no_match=ifelse(is.na(ADM2_NAME), 1, 0))
 
+  sia.03$Shape <- NULL
+
   # SIAs did not match with GUIDs in shapes.
   tofix <- sia.03 |>
     dplyr::select(-ADM0_NAME, -ADM1_NAME, -ADM2_NAME) |>
@@ -7271,6 +7273,8 @@ s3_sia_check_guids <- function(sia.02, long.global.dist.01){
     dplyr::mutate(missing.guid = ifelse(is.na(GUID), 1, 0),
                   adm2guid = ifelse(missing.guid==0, GUID, adm2guid)) |>
     dplyr::select(-GUID, -no_match)
+
+  tofix$Shape <- NULL
 
   # Combine SIAs matched with prov, dist with shapes
   sia.04 <- sia.03 |>


### PR DESCRIPTION
this PR removes shape var from SIA data in step 3, guid checking was retaining the shape variable from the district shapefiles this removes that.

to test you can run step 3 and ensure that the final SIA dataset doesn't contain any shape vars. you can also reference an old SIA dataset to make sure variable names are unchanged