### PR TITLE
190 add WHO region filtering capability for preprocessing function. 

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -388,7 +388,11 @@ freeze_polis_data <- function(){
 #'
 #' @description
 #' Create standard analytic datasets from raw POLIS data
+#'
 #' @param type str: specify the type of preprocessing to complete
+#' @param who_region str: optional WHO region to filter data
+#'      Available inputs include AFRO, AMRO, EMRO, EURO, SEARO and  WPRO.
+#'
 #' @import cli
 #' @returns Analytic rds files
 #' @examples
@@ -396,7 +400,7 @@ freeze_polis_data <- function(){
 #' preprocess_data(type = "cdc") #must run init_tidypolis to specify POLIS data location first
 #' }
 #' @export
-preprocess_data <- function(type){
+preprocess_data <- function(type, who_region = NULL){
 
   types <- c("cdc")
 
@@ -407,7 +411,7 @@ preprocess_data <- function(type){
   #CDC pre-processing steps
   if(type == "cdc"){
 
-    preprocess_cdc()
+    preprocess_cdc(who_region = who_region)
 
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -8339,15 +8339,15 @@ s5_pos_create_final_virus_data <- function(human.virus.05, env.virus.04) {
 #' @returns `NULL` quietly upon success.
 #' @keywords internal
 #'
-s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_data_folder, latest_folder_in_archive) {
+s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_data_folder, latest_folder_in_archive, output_folder_name) {
   cli::cli_process_start("Checking for variables that don't match last weeks pull")
 
   #Compare the final file to last week's final file to identify any differences in var_names, var_classes, or categorical responses
   new_table_metadata <- f.summarise.metadata(afp.es.virus.03)
 
-  x <- tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files/Archive", latest_folder_in_archive), full_names = T)
+  x <- tidypolis_io(io = "list", file_path = file.path(polis_data_folder, output_folder_name, "Archive", latest_folder_in_archive), full_names = T)
 
-  y <- tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files"), full_names = T)
+  y <- tidypolis_io(io = "list", file_path = file.path(polis_data_folder, output_folder_name), full_names = T)
 
   old.file <- x[grepl("positives_2001-01-01", x)]
 
@@ -8416,7 +8416,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
       # Export records for which virus type has changed from last week to this week in the CSV file:
       tidypolis_io(obj = pos_changed_virustype,
                    io = "write",
-                   file_path = paste0(polis_data_folder, "/Core_Ready_Files/Changed_virustype_virusTableData.csv"))
+                   file_path = paste0(polis_data_folder, "/", output_folder_name, "/Changed_virustype_virusTableData.csv"))
 
     }
 
@@ -8428,7 +8428,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
       # Export records for which virus type has changed from last week to this week in the CSV file:
       tidypolis_io(obj = in_new_not_old,
                    io = "write",
-                   file_path = paste0(polis_data_folder, "/Core_Ready_Files/in_new_not_old_virusTableData.csv"))
+                   file_path = paste0(polis_data_folder, "/", output_folder_name, "/in_new_not_old_virusTableData.csv"))
     }
 
   }else{
@@ -8448,7 +8448,9 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
   if(nrow(class.updated > 0)){
     tidypolis_io(obj = class.updated,
                  io = "write",
-                 file_path = paste0(polis_data_folder, "/Core_Ready_Files/virus_class_changed_date.csv"))
+                 file_path = paste0(polis_data_folder, "/",
+                                    output_folder_name,
+                                    "/virus_class_changed_date.csv"))
   }
 
   update_polis_log(.event = paste0("POS New Records: ", nrow(in_new_not_old), "; ",
@@ -8459,7 +8461,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
 
   tidypolis_io(obj = afp.es.virus.03,
                io = "write",
-               file_path = paste(polis_data_folder, "/Core_Ready_Files/",
+               file_path = paste(polis_data_folder, "/", output_folder_name, "/",
                                  paste("positives", min(afp.es.virus.03$dateonset, na.rm = T),
                                        max(afp.es.virus.03$dateonset, na.rm = T),
                                        sep = "_"

--- a/R/utils.R
+++ b/R/utils.R
@@ -7236,11 +7236,16 @@ s4_es_load_data <- function(polis_data_folder, latest_folder_in_archive,
 #' against the last download
 #' @param startyr `int` The subset of years for which to process ES data
 #' @param endyr `int` The subset of years for which to process ES data
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `tibble` es.02 SIA data with outputs validated
 #' @keywords internal
 #'
-s4_es_data_processing <- function(es.01.new){
+s4_es_data_processing <- function(es.01.new, startyr, endyr,
+                                  output_folder_name){
 
   # Data manipulation
 
@@ -7328,8 +7333,8 @@ s4_es_data_processing <- function(es.01.new){
 
     invisible(capture.output(
       tidypolis_io(obj = es.00, io = "write",
-                   file_path =  paste0(polis_data_folder,
-                                       "/Core_Ready_Files/duplicate_ES_sampleID_Polis.csv"))
+                   file_path =  paste0(polis_data_folder, "/", output_folder_name,
+                                       "/duplicate_ES_sampleID_Polis.csv"))
     ))
 
   } else {
@@ -7359,7 +7364,7 @@ s4_es_data_processing <- function(es.01.new){
     cli::cli_alert_warning(
       paste0("Writing out ES duplicates file: ",
              polis_data_folder,
-             "/Core_Ready_Files/duplicate_ES_Polis.csv -",
+             "/", output_folder_name, "/duplicate_ES_Polis.csv -",
              " please check, continuing processing"))
     es.dup.01 <- es.dup.01[order(es.dup.01$env.sample.id,es.dup.01$virus.type, es.dup.01$collect.yr),] |>
       dplyr::select(-es.dups)
@@ -7367,8 +7372,8 @@ s4_es_data_processing <- function(es.01.new){
     # Export duplicate viruses in the CSV file:
     invisible(capture.output(
       tidypolis_io(obj = es.dup.01, io = "write",
-                   file_path = paste0(polis_data_folder,
-                                      "/Core_Ready_Files/duplicate_ES_Polis.csv"))
+                   file_path = paste0(polis_data_folder, "/", output_folder_name,
+                                      "/duplicate_ES_Polis.csv"))
     ))
 
   } else {
@@ -7378,7 +7383,8 @@ s4_es_data_processing <- function(es.01.new){
   remove("es.dup.01")
 
   cli::cli_process_start("Checking for missingness in key ES vars")
-  check_missingness(data = es.02, type = "ES")
+  check_missingness(data = es.02, type = "ES",
+                    output_folder_name = output_folder_name)
   cli::cli_process_done("Review missing vars in es_missingness.rds")
 
   cli::cli_process_start("Cleaning 'virus.type' and creating CDC variables")

--- a/R/utils.R
+++ b/R/utils.R
@@ -6247,24 +6247,29 @@ s3_fully_process_sia_data <- function(long.global.dist.01, polis_data_folder,
 #'
 #' @param polis_data_folder `str` Path to the POLIS data folder.
 #' @param latest_folder_in_archive `str` Time stamp of latest folder in archive
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `tiblle` sia.01.new - the latest SIA data quality checked for variable
 #' stability against the last download if it exists
 #' @keywords internal
 #'
 s3_sia_load_data <- function(polis_data_folder,
-                             latest_folder_in_archive){
+                             latest_folder_in_archive,
+                             output_folder_name){
 
   # Step 1: Read in "old" data file (System to find "Old" data file)
   x <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files/Archive",
+                                          output_folder_name, "Archive",
                                           latest_folder_in_archive),
                     full_names = T)
 
   y <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files"),
+                                          output_folder_name),
                     full_names = T)
 
 
@@ -6362,10 +6367,14 @@ s3_sia_load_data <- function(polis_data_folder,
     cli::cli_process_start("Comparing downloaded variables")
     # Exclude the variables from
     sia.01.old.compare <- sia.01.old |>
-      dplyr::select(-var.list.01)
+      dplyr::select(
+        dplyr::any_of(var.list.01)
+      )
 
     sia.01.new.compare <- sia.01.new |>
-      dplyr::select(-var.list.01)
+      dplyr::select(
+        dplyr::any_of(var.list.01)
+      )
 
     new.var.sia.01 <- f.download.compare.01(sia.01.old.compare, sia.01.new.compare)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -6635,11 +6635,15 @@ s3_sia_check_duplicates <- function(sia.05){
 #' deduplicated
 #' @param polis_data_folder `str` Path to the POLIS data folder.
 #' @param latest_folder_in_archive `str` Time stamp of latest folder in archive
-#'
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #' @returns NULL
 #' @keywords internal
 #'
-s3_sia_check_metadata <- function(sia.06, polis_data_folder, latest_folder_in_archive){
+s3_sia_check_metadata <- function(sia.06, polis_data_folder, latest_folder_in_archive,
+                                  output_folder_name){
 
   cli::cli_process_start("Checking metadata")
   # This is the final SIA file which would be used for analysis.
@@ -6648,13 +6652,14 @@ s3_sia_check_metadata <- function(sia.06, polis_data_folder, latest_folder_in_ar
 
   x <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files/Archive",
+                                          output_folder_name,
+                                          "Archive",
                                           latest_folder_in_archive),
                     full_names = T)
 
   y <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files"),
+                                          output_folder_name),
                     full_names = T)
 
   sia.06 <- sia.06 |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -7180,11 +7180,15 @@ s3_sia_merge_cluster_dates_final_data <- function(
 #'
 #' @param sia.05 `tibble` the output of s3_sia_check_guids()
 #' @param polis_data_folder The POLIS data folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `NULL` silently.
 #' @keywords internal
 #'
-s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder){
+s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder, output_folder_name){
 
   cli::cli_process_start("Evaluating unmatched SIAs")
 
@@ -7208,7 +7212,7 @@ s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder){
                  io = "write",
                  file_path = paste(
                    polis_data_folder,
-                   "/Core_Ready_Files/",
+                   "/", output_folder_name, "/",
                    paste("ctry_sia_mismatch",
                          min(cty.yr.mismatch$yr.sia, na.rm = T),
                          max(cty.yr.mismatch$yr.sia, na.rm = T),

--- a/R/utils.R
+++ b/R/utils.R
@@ -8016,7 +8016,7 @@ s5_pos_create_cdc_vars <- function(virus.raw.new, polis_folder, polis_data_folde
 #' @returns `NULL` quietly upon success.
 #' @keywords internal
 #'
-s5_pos_check_duplicates <- function(virus.01, polis_data_folder) {
+s5_pos_check_duplicates <- function(virus.01, polis_data_folder, output_folder_name) {
   virus.dup.01 <- virus.01 |>
     dplyr::select(epid, epid.in.polis, pons.epid, virus.id, polis.case.id, env.sample.id,
                   place.admin.0, surveillance.type, datasource, virustype,
@@ -8033,7 +8033,7 @@ s5_pos_check_duplicates <- function(virus.01, polis_data_folder) {
       dplyr::select(-virus_dup)
 
     tidypolis_io(obj = virus.dup.01, io = "write",
-                 file_path = paste0(polis_data_folder, "/Core_Ready_Files/duplicate_viruses_Polis_virusTableData.csv"))
+                 file_path = paste0(polis_data_folder, "/", output_folder_name, "/duplicate_viruses_Polis_virusTableData.csv"))
 
     update_polis_log(.event = paste0("Duplicate viruses available in duplicate_viruses_Polis_virusTableData.csv"),
                      .event_type = "ALERT")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1839,10 +1839,12 @@ remove_character_dates <- function(type,
 #' @param polis_data_folder `str` Path to the POLIS data folder.
 #' @returns `tibble` Positives dataset with summary of SIA response variables.
 #' @keywords internal
-create_response_vars <- function(pos, polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")){
+create_response_vars <- function(pos,
+                                 output_folder_name,
+                                 polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")){
 
   #bring in processed SIA data
-  path <- tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "/Core_Ready_Files"), full_names = T)
+  path <- tidypolis_io(io = "list", file_path = file.path(Sys.getenv("POLIS_DATA_CACHE"), output_folder_name), full_names = T)
 
   tryCatch({
     sia <- tidypolis_io(io = "read", file_path = path[grepl("sia_2000", path)])

--- a/R/utils.R
+++ b/R/utils.R
@@ -8055,12 +8055,12 @@ s5_pos_check_duplicates <- function(virus.01, polis_data_folder, output_folder_n
 #' @returns `NULL` quietly upon success.
 #' @keywords internal
 #'
-s5_pos_write_missing_onsets <- function(virus.01, polis_data_folder) {
+s5_pos_write_missing_onsets <- function(virus.01, polis_data_folder, output_folder_name) {
   tidypolis_io(io = "write", obj = virus.01 |>
                  dplyr::select(epid, dateonset) |>
                  dplyr::filter(is.na(dateonset)),
-               file_path = paste0(polis_data_folder,
-                                  "/Core_Ready_Files/virus_missing_onset.csv"))
+               file_path = paste0(polis_data_folder, "/", output_folder_name,
+                                  "/virus_missing_onset.csv"))
 }
 
 #' Process and clean cases in the positives dataset

--- a/R/utils.R
+++ b/R/utils.R
@@ -5999,6 +5999,10 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
 #' @param col_afp_raw Names of columns in the original raw AFP data
 #' @param start_year Integer. Start year for filtering (default: 2020)
 #' @param end_year Integer. End year for filtering (default: current year)
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return A list containing comparison results:
 #'   - metadata_comparison: Structural differences between datasets
@@ -6019,7 +6023,8 @@ s2_compare_with_archive <- function(data,
                                     latest_archive,
                                     col_afp_raw,
                                     start_year = 2020,
-                                    end_year = lubridate::year(Sys.Date())) {
+                                    end_year = lubridate::year(Sys.Date()),
+                                    output_folder_name) {
   cli::cli_process_start("Comparing data with last AFP dataset")
 
   # Prepare data for comparison by standardizing types
@@ -6035,7 +6040,7 @@ s2_compare_with_archive <- function(data,
     archive_files <- tidypolis_io(
       io = "list",
       file_path = paste0(
-        polis_data_folder, "/Core_Ready_Files/Archive/",
+        polis_data_folder, "/", output_folder_name, "/Archive/",
         latest_archive
       ),
       full_names = TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -3867,19 +3867,25 @@ s1_clean_subactivity_table <- function(path, activity_table, crosswalk,
 #'
 #' @param polis_data_folder `str` Location of the POLIS data folder.
 #' @param timestamp `str` Folder name as the timestamp.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns NULL
 #' @keywords internal
 #'
-s1_create_core_ready_dir <- function(polis_data_folder, timestamp) {
+s1_create_core_ready_dir <- function(polis_data_folder, timestamp,
+                                     output_folder_name) {
+
   cli_process_start("Checking on requisite file structure")
 
   dirs <- c(
-    file.path(polis_data_folder, "Core_Ready_Files"),
-    file.path(polis_data_folder, "Core_Ready_Files", "Archive"),
-    file.path(polis_data_folder, "Core_Ready_Files", "Archive", timestamp),
-    file.path(polis_data_folder, "Core_Ready_Files", "Change Log"),
-    file.path(polis_data_folder, "Core_Ready_Files", "Change Log", timestamp)
+    file.path(polis_data_folder, output_folder_name),
+    file.path(polis_data_folder, output_folder_name, "Archive"),
+    file.path(polis_data_folder, output_folder_name, "Archive", timestamp),
+    file.path(polis_data_folder, output_folder_name, "Change Log"),
+    file.path(polis_data_folder, output_folder_name, "Change Log", timestamp)
   )
 
   sapply(dirs, function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -6676,20 +6676,22 @@ s3_sia_check_duplicates <- function(sia.05){
                   `wastage.factor` = as.character(`wastage.factor`),
                   sub.activity.start.date = as.POSIXct(round(as.POSIXct(sub.activity.start.date)),
                                                        format="%Y-%m-%d %H:%M:%S")) |>
-    dplyr::mutate_at(c("admin.1.id",
-                       "admin.2.id",
-                       "unpd.country.population",
-                       "immunized.population",
-                       "targeted.population",
-                       "number.of.doses",
-                       "admin.2.targeted.population",
-                       "admin.2.immunized.population",
-                       "admin2.children.inaccessible",
-                       "number.of.doses.approved",
-                       "children.inaccessible",
-                       "activity.parent.children.inaccessible",
-                       "admin.0.id" ),
-                     as.numeric)
+    dplyr::mutate(
+      dplyr::across(
+        dplyr::any_of(c("admin.1.id",
+                        "admin.2.id",
+                        "unpd.country.population",
+                        "immunized.population",
+                        "targeted.population",
+                        "number.of.doses",
+                        "admin.2.targeted.population",
+                        "admin.2.immunized.population",
+                        "admin2.children.inaccessible",
+                        "number.of.doses.approved",
+                        "children.inaccessible",
+                        "activity.parent.children.inaccessible",
+                        "admin.0.id" )),
+        as.numeric))
   options(scipen = savescipen)
 
   cli::cli_process_done()

--- a/R/utils.R
+++ b/R/utils.R
@@ -7124,24 +7124,31 @@ s4_fully_process_es_data <- function(polis_folder,
 
 #' Load and check ES data against previous downloads
 #'
-#' @inheritParams s4_fully_process_es_data
+#' @param polis_data_folder `str` Path to the POLIS data folder.
+#' @param latest_folder_in_archive `str` Time stamp of latest folder in archive
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
-#' @returns `tibble` es.01.new - the latest SIA data quality checked for variable
+#' @returns `tiblle` es.01.new - the latest SIA data quality checked for variable
 #' stability against the last download if it exists
 #' @keywords internal
 #'
-s4_es_load_data <- function(polis_data_folder, latest_folder_in_archive){
+s4_es_load_data <- function(polis_data_folder, latest_folder_in_archive,
+                            output_folder_name){
 
   # Step 1: Read in "old" data file (System to find "Old" data file)
   x <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files/Archive",
+                                          output_folder_name,
+                                          "Archive",
                                           latest_folder_in_archive),
                     full_names = T)
 
   y <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files"),
+                                          output_folder_name),
                     full_names = T)
 
   old.file <- x[grepl("EnvSamples",x)]

--- a/R/utils.R
+++ b/R/utils.R
@@ -4717,14 +4717,20 @@ s2_export_missing_onsets <- function(data, polis_data_folder, output_folder_name
 #' @param data A data frame containing AFP surveillance data
 #' @param type String indicating the type of data (e.g., "AFP")
 #' @param polis_data_folder String path to the POLIS data folder
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return Invisibly returns the missingness summary
 #' @export
-s2_check_missingness <- function(data, type = "AFP", polis_data_folder) {
+s2_check_missingness <- function(data, type = "AFP", polis_data_folder,
+                                 output_folder_name) {
   cli::cli_process_start("Checking for missingness in key variables")
 
   # Call the existing check_missingness function
-  result <- check_missingness(data = data, type = type)
+  result <- check_missingness(data = data, type = type,
+                              output_folder_name = output_folder_name)
 
   cli::cli_process_done(
     paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -1790,11 +1790,17 @@ archive_log <- function(log_file = Sys.getenv("POLIS_LOG_FILE"),
 #' @param type str: the table on which to remove original date vars, "AFP", "ES", "POS"
 #' @param df tibble: the dataframe from which to remove character formatted dates
 #' @param polis_data_folder str:  location of user's polis data folder
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
+#'
 #' @return outputs a saved reference table of original date vars and a smaller
 #' core ready file without character dates
 remove_character_dates <- function(type,
                                    df,
-                                   polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")){
+                                   polis_data_folder = Sys.getenv("POLIS_DATA_CACHE"),
+                                   output_folder_name){
 
   if(type %in% c("AFP", "POS")){
     df.01 <- df |>
@@ -1818,7 +1824,7 @@ remove_character_dates <- function(type,
 
   }
 
-  tidypolis_io(io = "write", obj = df.01, file_path = paste0(polis_data_folder, "/Core_Ready_Files/", type, "_orig_char_dates.rds"))
+  tidypolis_io(io = "write", obj = df.01, file_path = paste0(polis_data_folder, "/", output_folder_name, "/", type, "_orig_char_dates.rds"))
 
   return(df.02)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7660,11 +7660,15 @@ s4_es_check_metadata <- function(polis_data_folder, es.05,
 #' @param es.05 `tibble` The latest ES download with variables checked
 #' against the last download, variables validated and sites checked and
 #' CDC variables enforced
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `NULL` invisible return with write out to logs if necessary
 #' @keywords internal
 #'
-s4_es_write_data <- function(polis_data_folder, es.05){
+s4_es_write_data <- function(polis_data_folder, es.05, output_folder_name){
 
   cli::cli_process_start("Writing out ES datasets")
 
@@ -7674,7 +7678,9 @@ s4_es_write_data <- function(polis_data_folder, es.05){
       io = "write",
       file_path = paste(
         polis_data_folder,
-        "/Core_Ready_Files/",
+        "/",
+        output_folder_name,
+        "/",
         paste("es", min(es.05$collect.date, na.rm = T),
               max(es.05$collect.date, na.rm = T), sep = "_"),
         ".rds",

--- a/R/utils.R
+++ b/R/utils.R
@@ -6727,14 +6727,19 @@ s3_sia_check_metadata <- function(sia.06, polis_data_folder, latest_folder_in_ar
 #' against the last download, CDC variables created, GUIDs validated and
 #' deduplicated
 #' @param polis_data_folder `str` Path to the POLIS data folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns NULL
 #' @keywords internal
 #'
-s3_sia_write_precluster_data <- function(sia.06, polis_data_folder){
+s3_sia_write_precluster_data <- function(sia.06, polis_data_folder,
+                                         output_folder_name){
   cli::cli_process_start("Writing out SIA file")
   # Write final SIA file to RDS file
-  sia.file.path <- paste(polis_data_folder, "/Core_Ready_Files/", sep = "")
+  sia.file.path <- paste(polis_data_folder, "/", output_folder_name, "/", sep = "")
 
   invisible(capture.output(
     tidypolis_io(obj = sia.06, io = "write",

--- a/R/utils.R
+++ b/R/utils.R
@@ -7562,11 +7562,16 @@ s4_es_create_cdc_vars <- function(es.02, polis_folder){
 #' @param es.05 `tibble` The latest ES download with variables checked
 #' against the last download, variables validated and sites checked and
 #' CDC variables enforced
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `NULL` invisible return with write out to logs if necessary
 #' @keywords internal
 #'
 s4_es_check_metadata <- function(polis_data_folder, es.05,
+                                 output_folder_name,
                                  latest_folder_in_archive){
 
   cli::cli_process_start("Checking metadata with previous data")
@@ -7578,7 +7583,8 @@ s4_es_check_metadata <- function(polis_data_folder, es.05,
     io = "list",
     file_path = file.path(
       polis_data_folder,
-      "Core_Ready_Files/Archive",
+      output_folder_name,
+      "Archive",
       latest_folder_in_archive),
     full_names = T)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -7477,12 +7477,16 @@ s4_es_validate_sites <- function(es.02){
 #'
 #' @param es.02 `tibble` The latest ES download with variables checked
 #' against the last download, variables validated and sites checked
-#' @inheritParams s4_fully_process_es_data
+#' @param polis_folder `str` Path to the main POLIS folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `tibble` es.05 SIA data with CDC variables enforced
 #' @keywords internal
 #'
-s4_es_create_cdc_vars <- function(es.02, polis_folder){
+s4_es_create_cdc_vars <- function(es.02, polis_folder, output_folder_name){
 
 
   cli::cli_process_start("Creating ES CDC variables")
@@ -7501,25 +7505,25 @@ s4_es_create_cdc_vars <- function(es.02, polis_folder){
 
   invisible(capture.output(
     global.ctry.01 <- switch(Sys.getenv("POLIS_EDAV_FLAG"),
-    "TRUE" = {
-      sirfunctions::load_clean_ctry_sp(fp = file.path(
-        "GID/PEB/SIR",
-        polis_folder,
-        "misc",
-        "global.ctry.rds"
-      ))
-    },
-    "FALSE" = {
-      sirfunctions::load_clean_ctry_sp(
-        fp = file.path(
-          polis_folder,
-          "misc",
-          "global.ctry.rds"
-        ),
-        edav = FALSE
-      )
-    })
-    ))
+                             "TRUE" = {
+                               sirfunctions::load_clean_ctry_sp(fp = file.path(
+                                 "GID/PEB/SIR",
+                                 polis_folder,
+                                 "misc",
+                                 "global.ctry.rds"
+                               ))
+                             },
+                             "FALSE" = {
+                               sirfunctions::load_clean_ctry_sp(
+                                 fp = file.path(
+                                   polis_folder,
+                                   "misc",
+                                   "global.ctry.rds"
+                                 ),
+                                 edav = FALSE
+                               )
+                             })
+  ))
 
   sf::sf_use_s2(F)
   shape.name.01 <- global.ctry.01 |>
@@ -7546,7 +7550,8 @@ s4_es_create_cdc_vars <- function(es.02, polis_folder){
                      ~as.numeric(.)) |>
     dplyr::distinct()
 
-  es.05 <- remove_character_dates(type = "ES", df = es.04)
+  es.05 <- remove_character_dates(type = "ES", df = es.04,
+                                  output_folder_name = output_folder_name)
 
   options(scipen = savescipen)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -8484,7 +8484,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
 #' @returns `NULL` quietly upon success.
 #' @keywords internal
 #'
-s5_pos_evaluate_unmatched_guids <- function(afp.es.virus.03, long.global.dist.01, polis_data_folder) {
+s5_pos_evaluate_unmatched_guids <- function(afp.es.virus.03, long.global.dist.01, polis_data_folder, output_folder_name) {
   cli::cli_process_start("Checking for positives that don't match to GUIDs")
 
   # AFP and ES that do not match to shape file
@@ -8495,7 +8495,7 @@ s5_pos_evaluate_unmatched_guids <- function(afp.es.virus.03, long.global.dist.01
 
   tidypolis_io(obj = unmatched.afp.es.viruses.01,
                io = "write",
-               file_path = paste(polis_data_folder, "/Core_Ready_Files/",
+               file_path = paste(polis_data_folder, "/", output_folder_name, "/",
                                  paste("unmatch_positives", min(unmatched.afp.es.viruses.01$yronset, na.rm = T),
                                        max(unmatched.afp.es.viruses.01$yronset, na.rm = T),
                                        sep = "_"

--- a/R/utils.R
+++ b/R/utils.R
@@ -4461,6 +4461,10 @@ s2_read_afp_data <- function(file_path) {
 #'
 #' @param data A dataframe containing AFP surveillance data
 #' @param polis_data_folder String path to the POLIS data folder
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return Logical. TRUE if duplicates found, FALSE if no duplicates
 #'
@@ -4476,7 +4480,7 @@ s2_read_afp_data <- function(file_path) {
 #' \dontrun{
 #' s2_check_duplicated_epids(afp_data, "path/to/polis/folder")
 #' }
-s2_check_duplicated_epids <- function(data, polis_data_folder) {
+s2_check_duplicated_epids <- function(data, polis_data_folder, output_folder_name) {
   cli::cli_process_start("Checking for duplicated EPIDs")
 
   afp_dup <- data |>
@@ -4501,37 +4505,37 @@ s2_check_duplicated_epids <- function(data, polis_data_folder) {
   if (nrow(afp_dup) >= 1) {
     # Export duplicate afp cases in the CSV file:
     invisible(capture.output(
-          tidypolis_io(
-            io = "write",
-            obj = afp_dup,
-            paste0(
-              polis_data_folder,
-              "/Core_Ready_Files/",
-              paste(
-                "duplicate_AFPcases_Polis",
-                min(afp_dup$yronset, na.rm = TRUE),
-                max(afp_dup$yronset, na.rm = TRUE),
-                sep = "_"
-              ),
-              ".csv"
-            )
-          )
+      tidypolis_io(
+        io = "write",
+        obj = afp_dup,
+        paste0(
+          polis_data_folder,
+          "/", output_folder_name, "/",
+          paste(
+            "duplicate_AFPcases_Polis",
+            min(afp_dup$yronset, na.rm = TRUE),
+            max(afp_dup$yronset, na.rm = TRUE),
+            sep = "_"
+          ),
+          ".csv"
+        )
+      )
     ))
 
     cli::cli_alert_info(
       paste0(
         "Duplicate AFP case. Check the data for duplicate records located at:\n",
-                    paste0(
-              polis_data_folder,
-              "/Core_Ready_Files/",
-              paste(
-                "duplicate_AFPcases_Polis",
-                min(afp_dup$yronset, na.rm = TRUE),
-                max(afp_dup$yronset, na.rm = TRUE),
-                sep = "_"
-              ),
-              ".csv"
-            ), "\n",
+        paste0(
+          polis_data_folder,
+          "/", output_folder_name, "/",
+          paste(
+            "duplicate_AFPcases_Polis",
+            min(afp_dup$yronset, na.rm = TRUE),
+            max(afp_dup$yronset, na.rm = TRUE),
+            sep = "_"
+          ),
+          ".csv"
+        ), "\n",
         "If they are exact same, then contact POLIS"
       )
     )
@@ -4539,7 +4543,7 @@ s2_check_duplicated_epids <- function(data, polis_data_folder) {
     update_polis_log(
       .event = paste0(
         "Duplicate AFP cases output in ",
-        "duplicate_AFPcases_Polis within Core_Ready_files"
+        "duplicate_AFPcases_Polis within ", output_folder_name,
       ),
       .event_type = "ALERT"
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -5673,11 +5673,15 @@ s2_create_afp_variables <- function(data) {
 #' @param latest_archive String containing the name of the latest archive folder
 #' @param polis_data_folder String path to the POLIS data folder
 #' @param col_afp_raw Names of original columns for comparison
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return Invisibly returns NULL
 #' @export
 s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
-                                  col_afp_raw) {
+                                  col_afp_raw, output_folder_name) {
 
   cli::cli_process_start("Exporting AFP outputs",
                          msg_done = "Exported AFP outputs")
@@ -5709,27 +5713,29 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
 
   # Export missing guid files
   invisible(capture.output(
-      tidypolis_io(
-        obj = afp_missing_count,
-        io = "write",
-        file_path = paste0(
-          polis_data_folder, "/Core_Ready_Files/afp_missing_guid_count_",
-          min(data$dateonset, na.rm = TRUE), "_",
-          max(data$dateonset, na.rm = TRUE), ".csv"
-        )
+    tidypolis_io(
+      obj = afp_missing_count,
+      io = "write",
+      file_path = paste0(
+        polis_data_folder, "/", output_folder_name,
+        "/afp_missing_guid_count_",
+        min(data$dateonset, na.rm = TRUE), "_",
+        max(data$dateonset, na.rm = TRUE), ".csv"
       )
+    )
   ))
 
   invisible(capture.output(
-      tidypolis_io(
-        obj = afp_missing_epids,
-        io = "write",
-        file_path = paste0(
-          polis_data_folder, "/Core_Ready_Files/afp_missing_guid_epids_",
-          min(data$dateonset, na.rm = TRUE), "_",
-          max(data$dateonset, na.rm = TRUE), ".csv"
-        )
+    tidypolis_io(
+      obj = afp_missing_epids,
+      io = "write",
+      file_path = paste0(
+        polis_data_folder, "/",  output_folder_name,
+        "/afp_missing_guid_epids_",
+        min(data$dateonset, na.rm = TRUE), "_",
+        max(data$dateonset, na.rm = TRUE), ".csv"
       )
+    )
   ))
 
   # Prepare data for export
@@ -5745,20 +5751,22 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     data = afp_data,
     polis_data_folder = polis_data_folder,
     latest_archive = latest_archive,
-    col_afp_raw = col_afp_raw
+    col_afp_raw = col_afp_raw,
+    output_folder_name = output_folder_name
   )
 
   # Export AFP linelist
   invisible(capture.output(
-      tidypolis_io(
-        obj = afp_data,
-        io = "write",
-        file_path = paste0(
-          polis_data_folder, "/Core_Ready_Files/afp_linelist_",
-          min(afp_data$dateonset, na.rm = TRUE), "_",
-          max(afp_data$dateonset, na.rm = TRUE), ".rds"
-        )
+    tidypolis_io(
+      obj = afp_data,
+      io = "write",
+      file_path = paste0(
+        polis_data_folder, "/",
+        output_folder_name, "/afp_linelist_",
+        min(afp_data$dateonset, na.rm = TRUE), "_",
+        max(afp_data$dateonset, na.rm = TRUE), ".rds"
       )
+    )
   ))
 
 
@@ -5771,15 +5779,15 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     )
 
   invisible(capture.output(
-      tidypolis_io(
-        obj = afp_latlong,
-        io = "write",
-        file_path = paste0(
-          polis_data_folder, "/Core_Ready_Files/afp_lat_long_",
-          min(afp_latlong$dateonset, na.rm = TRUE), "_",
-          max(afp_latlong$dateonset, na.rm = TRUE), ".csv"
-        )
+    tidypolis_io(
+      obj = afp_latlong,
+      io = "write",
+      file_path = paste0(
+        polis_data_folder, "/", output_folder_name, "/afp_lat_long_",
+        min(afp_latlong$dateonset, na.rm = TRUE), "_",
+        max(afp_latlong$dateonset, na.rm = TRUE), ".csv"
       )
+    )
   ))
 
 
@@ -5790,7 +5798,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
   # Find all AFP files in Core_Ready_Files and core_files_to_combine
   afp_files_main <- dplyr::tibble("name" = tidypolis_io(
     io = "list",
-    file_path = paste0(polis_data_folder, "/Core_Ready_Files"),
+    file_path = paste0(polis_data_folder, "/", output_folder_name),
     full_names = TRUE
   )) |>
     dplyr::filter(grepl("^.*(afp_linelist).*(.rds)$", name)) |>
@@ -5836,7 +5844,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         io = "write",
         file_path = paste0(
           polis_data_folder,
-          "/Core_Ready_Files/",
+          "/", output_folder_name, "/",
           "afp_linelist_",
           min(afp_combined$dateonset, na.rm = TRUE),
           "_",
@@ -5857,8 +5865,8 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         io = "write",
         file_path = paste0(
           polis_data_folder,
-          "/Core_Ready_Files/",
-          "afp_linelist_",
+          "/", output_folder_name,
+          "/afp_linelist_",
           min(afp_light$dateonset, na.rm = TRUE),
           "_",
           max(afp_light$dateonset, na.rm = TRUE),
@@ -5890,7 +5898,8 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         io = "write",
         file_path = paste0(
           polis_data_folder,
-          "/Core_Ready_Files/other_surveillance_type_linelist_",
+          "/", output_folder_name,
+          "/other_surveillance_type_linelist_",
           min(other_surv$yronset, na.rm = TRUE), "_",
           max(other_surv$yronset, na.rm = TRUE), ".rds"
         )
@@ -5904,7 +5913,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     # Find all other surveillance files in Core_Ready_Files and core_files_to_combine
     other_files_main <- dplyr::tibble("name" = tidypolis_io(
       io = "list",
-      file_path = paste0(polis_data_folder, "/Core_Ready_Files"),
+      file_path = paste0(polis_data_folder, "/", output_folder_name),
       full_names = TRUE
     )) |>
       dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
@@ -5927,21 +5936,21 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         ))
       ))
 
-     other_to_combine <- other_to_combine |>
-      dplyr::mutate(
-        stool1tostool2 = as.numeric(stool1tostool2),
-        datenotificationtohq = lubridate::parse_date_time(
-          datenotificationtohq,
-          c("dmY", "bY", "Ymd", "%Y-%m-%d %H:%M:%S")
+      other_to_combine <- other_to_combine |>
+        dplyr::mutate(
+          stool1tostool2 = as.numeric(stool1tostool2),
+          datenotificationtohq = lubridate::parse_date_time(
+            datenotificationtohq,
+            c("dmY", "bY", "Ymd", "%Y-%m-%d %H:%M:%S")
+          )
         )
-      )
 
-     invisible(capture.output(
-       other_new <- purrr::map_df(
-         other_files_main,
-         ~ tidypolis_io(io = "read", file_path = .x)
-       )
-     ))
+      invisible(capture.output(
+        other_new <- purrr::map_df(
+          other_files_main,
+          ~ tidypolis_io(io = "read", file_path = .x)
+        )
+      ))
 
       other_combined <- dplyr::bind_rows(other_new, other_to_combine)
 
@@ -5952,8 +5961,8 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
           io = "write",
           file_path = paste0(
             polis_data_folder,
-            "/Core_Ready_Files/",
-            "other_surveillance_type_linelist_",
+            "/", output_folder_name,
+            "/other_surveillance_type_linelist_",
             min(other_combined$yronset, na.rm = TRUE),
             "_",
             max(other_combined$yronset, na.rm = TRUE),
@@ -5962,19 +5971,19 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         )
       ))
 
+      cli::cli_process_done()
+    }
+
+    update_polis_log(
+      .event = "AFP and Other Surveillance Linelists Finished",
+      .event_type = "PROCESS"
+    )
+
     cli::cli_process_done()
-  }
 
-  update_polis_log(
-    .event = "AFP and Other Surveillance Linelists Finished",
-    .event_type = "PROCESS"
-  )
+    gc(full = TRUE)
 
-  cli::cli_process_done()
-
-  gc(full = TRUE)
-
-  invisible(NULL)
+    invisible(NULL)
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -6613,7 +6613,7 @@ s3_sia_check_guids <- function(sia.02, long.global.dist.01){
                             "yr.sia" = "active.year.01")) |>
     #flag if guids still missing and merge in reference GUID
     dplyr::mutate(missing.guid = ifelse(is.na(GUID), 1, 0),
-                  adm2guid = ifelse(missing.guid==0, GUID, adm2guid)) |>
+                  adm2guid = dplyr::if_else(missing.guid==0, GUID, adm2guid)) |>
     dplyr::select(-GUID, -no_match)
 
   # Combine SIAs matched with prov, dist with shapes

--- a/R/utils.R
+++ b/R/utils.R
@@ -2034,8 +2034,12 @@ cluster_dates <- function(x,
 #' @import dplyr
 #' @param data tibble the datatable for which we want to check key variable missingness
 #' @param type str "AFP", "ES", or "POS", type of dataset to check missingness
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 check_missingness <- function(data,
-                              type) {
+                              type, output_folder_name) {
 
   if (type == "AFP") {
 
@@ -2053,8 +2057,9 @@ check_missingness <- function(data,
     invisible(capture.output(
       tidypolis_io(io = "write",
                    obj = missing_by_group,
-                   file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"),
-                                      "/Core_Ready_Files/afp_missingness.rds"))
+                   file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/",
+                                      output_folder_name,
+                                      "/afp_missingness.rds"))
     ))
 
 
@@ -2072,8 +2077,8 @@ check_missingness <- function(data,
       invisible(capture.output(
         tidypolis_io(io = "write",
                      obj = missing_by_group,
-                     file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"),
-                                        "/Core_Ready_Files/es_missingness.rds"))
+                     file_path = paste0(Sys.getenv("POLIS_DATA_CACHE"), "/",
+                                        output_folder_name, "/es_missingness.rds"))
       ))
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3769,7 +3769,8 @@ s1_clean_activity_table <- function(path, subactivity_path, crosswalk,
     rename_via_crosswalk(api_data = api_activity_sub1,
                          crosswalk = crosswalk,
                          table_name = "Activity") |>
-    dplyr::select(SIASubActivityCode, crosswalk$Web_Name[crosswalk$Table == "Activity"]) |>
+    dplyr::select(SIASubActivityCode, WHORegion,
+                  crosswalk$Web_Name[crosswalk$Table == "Activity"]) |>
     dplyr::select(-c("Admin 0 Id"))
   cli::cli_process_done()
 
@@ -3913,7 +3914,7 @@ s1_clean_subactivity_table <- function(path, activity_table, crosswalk,
                                          !is.na(crosswalk$Web_Name)],
                     crosswalk$API_Name[crosswalk$Table %in% c("SubActivity") &
                                          is.na(crosswalk$Web_Name) &
-                                         crosswalk$API_Name != "ActivityAdminCoveragePercentage"]))
+                                         crosswalk$API_Name != "ActivityAdminCoveragePercentage"]), WHORegion)
   cli::cli_process_done()
 
   rm(api_subactivity_sub3)

--- a/R/utils.R
+++ b/R/utils.R
@@ -4336,14 +4336,19 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
 #'   validation.
 #' @param timestamp `str` Time stamp
 #' @param latest_folder_in_archive_path `str` The path to the latest archive folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @export
 s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
                                       long.global.dist.01, timestamp,
-                                      latest_folder_in_archive_path) {
+                                      latest_folder_in_archive_path,
+                                      output_folder_name) {
 
   if (!tidypolis_io(io = "exists.dir",
-                    file_path = file.path(polis_data_folder, "Core_Ready_Files"))) {
+                    file_path = file.path(polis_data_folder, output_folder_name))) {
     cli::cli_abort("Please run Step 1 and create a Core Ready folder before running this step.")
   }
 
@@ -4353,7 +4358,7 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
   x <- tidypolis_io(
     io = "list",
     file_path = file.path(
-      polis_data_folder, "Core_Ready_Files/Archive",
+      polis_data_folder, output_folder_name, "Archive",
       latest_folder_in_archive_path
     ),
     full_names = TRUE
@@ -4362,7 +4367,7 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
   # load new data files
   y <- tidypolis_io(
     io = "list",
-    file_path = file.path(polis_data_folder, "Core_Ready_Files"),
+    file_path = file.path(polis_data_folder, output_folder_name),
     full_names = TRUE
   )
 
@@ -4373,7 +4378,7 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
   # Step 2b: Check for duplicate EPIDs
   has_duplicates <- s2_check_duplicated_epids(
     data = afp_raw_new,
-    polis_data_folder = polis_data_folder)
+    polis_data_folder = polis_data_folder, output_folder_name = output_folder_name)
 
   if (has_duplicates) {
     cli::cli_alert_warning("Please review duplicates!")
@@ -4385,13 +4390,14 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
   # Step 2d: Write out epids with no dateonset
   s2_export_missing_onsets(
     data = afp_standardized,
-    polis_data_folder = polis_data_folder)
+    polis_data_folder = polis_data_folder, output_folder_name = output_folder_name)
 
   # Step 2e: Check for missingness
   s2_check_missingness(
     data = afp_standardized,
     type = "AFP",
-    polis_data_folder)
+    polis_data_folder,
+    output_folder_name)
 
   # Step 2f: Classify cases
   afp_classified <- s2_classify_afp_cases(
@@ -4412,7 +4418,8 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
   afp_processed <- s2_process_coordinates(
     data = afp_with_guids,
     polis_data_folder = polis_data_folder,
-    polis_folder = polis_folder
+    polis_folder = polis_folder,
+    output_folder_name = output_folder_name
   )
 
   # Step 2j: Create key AFP variables
@@ -4423,7 +4430,8 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
     data = afp_final,
     latest_archive = latest_folder_in_archive_path,
     polis_data_folder = polis_data_folder,
-    col_afp_raw = colnames(afp_raw_new)
+    col_afp_raw = colnames(afp_raw_new),
+    output_folder_name = output_folder_name
   )
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3902,16 +3902,21 @@ s1_create_core_ready_dir <- function(polis_data_folder, timestamp,
 #' Gets the most recent files in the Core Ready folder
 #'
 #' @param polis_data_folder `str` Location of the POLIS data folder.
-#' @param patterns `list` A list of patterns to select files.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `list` With names of the most recent files that matches the patterns.
 #' @keywords internal
 #'
-s1_get_most_recent_files <- function(polis_data_folder, patterns) {
+s1_get_most_recent_files <- function(polis_data_folder, patterns,
+                                     output_folder_name) {
   files <- tidypolis_io(
     io = "list",
-    file_path = file.path(polis_data_folder, "Core_Ready_Files")
+    file_path = file.path(polis_data_folder, output_folder_name)
   )
+
   files <- files[grepl(paste(patterns, collapse = "|"), files)]
 
   return(files)

--- a/R/utils.R
+++ b/R/utils.R
@@ -7259,7 +7259,8 @@ s4_fully_process_es_data <- function(
   es.05 <- s4_es_load_data(polis_data_folder = polis_data_folder,
                            latest_folder_in_archive = latest_folder_in_archive,
                            output_folder_name = output_folder_name) |>
-    s4_es_data_processing(output_folder_name = output_folder_name) |>
+    s4_es_data_processing(output_folder_name = output_folder_name,
+                          polis_data_folder = polis_data_folder) |>
     s4_es_validate_sites() |>
     s4_es_create_cdc_vars(
       polis_folder = polis_folder,
@@ -7398,12 +7399,14 @@ s4_es_load_data <- function(polis_data_folder, latest_folder_in_archive,
 #'        files will be saved. Defaults to "Core_Ready_Files". For
 #'        region-specific processing, this should be set to
 #'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
+#' @param polis_data_folder `str` Path to the POLIS data folder.
 #'
 #' @returns `tibble` es.02 SIA data with outputs validated
 #' @keywords internal
 #'
 s4_es_data_processing <- function(es.01.new, startyr, endyr,
-                                  output_folder_name){
+                                  output_folder_name,
+                                  polis_data_folder){
 
   # Data manipulation
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -5321,10 +5321,15 @@ s2_fix_admin_guids <- function(data, shape_data) {
 #' @param polis_data_folder `str` Path to the POLIS data folder containing
 #'   Core_Ready_Files.
 #' @param polis_folder `str` Path to the main POLIS folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return A tibble with processed coordinate data
 #' @export
-s2_process_coordinates <- function(data, polis_data_folder, polis_folder) {
+s2_process_coordinates <- function(data, polis_data_folder, polis_folder,
+                                   output_folder_name) {
 
   cli::cli_process_start("Processing GPS coordinates for AFP cases",
                          msg_done = "Processed GPS coordinates for AFP cases"
@@ -5376,19 +5381,19 @@ s2_process_coordinates <- function(data, polis_data_folder, polis_folder) {
   if (nrow(dup_epid) > 0) {
     # Export duplicates
     invisible(capture.output(
-          tidypolis_io(
-            obj = dup_epid,
-            io = "write",
-            file_path = paste0(
-              polis_data_folder,
-              "/Core_Ready_Files/",
-              "duplicate_AFP_epids_Polis_",
-              min(dup_epid$yronset, na.rm = TRUE),
-              "_",
-              max(dup_epid$yronset, na.rm = TRUE),
-              ".csv"
-            )
-          )
+      tidypolis_io(
+        obj = dup_epid,
+        io = "write",
+        file_path = paste0(
+          polis_data_folder,
+          "/", output_folder_name,
+          "/duplicate_AFP_epids_Polis_",
+          min(dup_epid$yronset, na.rm = TRUE),
+          "_",
+          max(dup_epid$yronset, na.rm = TRUE),
+          ".csv"
+        )
+      )
     ))
 
     # Remove duplicates
@@ -5415,14 +5420,15 @@ s2_process_coordinates <- function(data, polis_data_folder, polis_folder) {
   if (nrow(afp_noshape) > 0) {
 
     invisible(capture.output(
-          tidypolis_io(
-            obj = afp_noshape,
-            io = "write",
-            file_path = paste0(
-              polis_data_folder,
-              "/Core_Ready_Files/AFP_epids_bad_guid.csv"
-            )
-          )
+      tidypolis_io(
+        obj = afp_noshape,
+        io = "write",
+        file_path = paste0(
+          polis_data_folder, "/",
+          output_folder_name,
+          "/AFP_epids_bad_guid.csv"
+        )
+      )
     ))
 
     cli::cli_alert_warning(paste0(
@@ -5444,15 +5450,15 @@ s2_process_coordinates <- function(data, polis_data_folder, polis_folder) {
   if (nrow(empty_coord_check) > 0) {
 
     invisible(capture.output(
-          tidypolis_io(
-            io = "write",
-            file_path = paste0(polis_data_folder,
-                              "/Core_Ready_Files/afp_empty_coords.csv"),
-            obj = empty_coord_check |>
-              dplyr::select(polis.case.id, epid, date.onset,
-                            place.admin.0, polis.latitude,
-                            polis.longitude)
-          )
+      tidypolis_io(
+        io = "write",
+        file_path = paste0(polis_data_folder, "/", output_folder_name,
+                           "/afp_empty_coords.csv"),
+        obj = empty_coord_check |>
+          dplyr::select(polis.case.id, epid, date.onset,
+                        place.admin.0, polis.latitude,
+                        polis.longitude)
+      )
     ))
 
     cli::cli_alert_warning(

--- a/R/utils.R
+++ b/R/utils.R
@@ -4376,6 +4376,10 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
 #' @param polis_data_folder `str` specifying the path to the main
 #' data folder containing Core Ready Files
 #' @param timestamp `str` Time stamp
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return `str` containing either the name of the most recent
 #'   archive folder or the current timestamp if no archives exist
@@ -4392,10 +4396,10 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
 #' latest_archive <- find_latest_archive("path/to/polis/data")
 #' }
 #' @keywords internal
-s2_find_latest_archive <- function(polis_data_folder, timestamp) {
+s2_find_latest_archive <- function(polis_data_folder, timestamp, output_folder_name) {
   latest_folder_in_archive <- tidypolis_io(
     io = "list",
-    file_path = paste0(polis_data_folder, "/Core_Ready_Files/Archive")
+    file_path = paste0(polis_data_folder, "/", output_folder_name, "/Archive")
   ) |>
     dplyr::tibble() |>
     dplyr::rename(name = 1) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -7951,7 +7951,8 @@ s5_fully_process_pos_data <- function(polis_folder,
 #' @returns `tibble` New virus dataset.
 #' @keywords internal
 #'
-s5_pos_load_data <- function(polis_data_folder, latest_folder_in_archive) {
+s5_pos_load_data <- function(polis_data_folder, latest_folder_in_archive,
+                             output_folder_name) {
   update_polis_log(.event = "Creating Positives analytic datasets",
                    .event_type = "PROCESS")
 
@@ -7960,13 +7961,13 @@ s5_pos_load_data <- function(polis_data_folder, latest_folder_in_archive) {
   # Step 1: Read in "old" data file (System to find "Old" data file)
   x <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files/Archive",
+                                          output_folder_name, "Archive",
                                           latest_folder_in_archive),
                     full_names = T)
 
   y <- tidypolis_io(io = "list",
                     file_path = file.path(polis_data_folder,
-                                          "Core_Ready_Files"),
+                                          output_folder_name),
                     full_names = T)
 
   old.file <- x[grepl("Viruses_",x)]

--- a/R/utils.R
+++ b/R/utils.R
@@ -4165,6 +4165,10 @@ s1_archive_old_files <- function(polis_data_folder, timestamp, output_folder_nam
 #' @param api_subactivity_data `tibble` Cleaned Subactivity table.
 #' @param api_es_data `tibble` Cleaned ES table.
 #' @param api_virus_data `tibble` Cleaned Virus table.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `NULL`
 #' @keywords internal
@@ -4173,7 +4177,8 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
                                              api_case_data,
                                              api_subactivity_data,
                                              api_es_data,
-                                             api_virus_data) {
+                                             api_virus_data,
+                                             output_folder_name) {
 
   cli::cli_process_start("Writing all final Core Ready files")
 
@@ -4183,7 +4188,7 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
       io = "write",
       file_path = file.path(
         polis_data_folder,
-        "Core_Ready_Files",
+        output_folder_name,
         paste0(
           "Human_Detailed_Dataset_",
           timestamp,
@@ -4201,7 +4206,7 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
       io = "write",
       file_path = file.path(
         polis_data_folder,
-        "Core_Ready_Files",
+        output_folder_name,
         paste0(
           "Activity_Data_with_All_Sub-Activities_(1_district_per_row)_",
           timestamp,
@@ -4219,7 +4224,7 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
       io = "write",
       file_path = file.path(
         polis_data_folder,
-        "Core_Ready_Files",
+        output_folder_name,
         paste0(
           "EnvSamples_Detailed_Dataset_",
           timestamp,
@@ -4237,7 +4242,7 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
       io = "write",
       file.path(
         polis_data_folder,
-        "Core_Ready_Files",
+        output_folder_name,
         paste0(
           "Viruses_Detailed_Dataset_",
           timestamp,

--- a/R/utils.R
+++ b/R/utils.R
@@ -7021,13 +7021,19 @@ s3_sia_cluster_dates_by_vax_type <- function(data,
 #' @param sia.clean.01 `tibble` all cleaned and historical SIA data without rounds
 #' @param polis_folder `str` Path to the POLIS folder.
 #' @param polis_data_folder `str` Path to the POLIS data folder.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
+#'
 #' @returns `NULL` silently.
 #' @keywords internal
 #'
 s3_sia_merge_cluster_dates_final_data <- function(
     sia.clean.01,
     polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
-    polis_data_folder = file.path(polis_folder, "data")
+    polis_data_folder = file.path(polis_folder, "data"),
+    output_folder_name
 ){
 
   cli::cli_process_start("Reading in cached SIA cluster data")
@@ -7081,7 +7087,7 @@ s3_sia_merge_cluster_dates_final_data <- function(
                  io = "write",
                  file_path = paste(
                    polis_data_folder,
-                   "/Core_Ready_Files/",
+                   "/", output_folder_name, "/",
                    paste("sia", min(sia.clean.02$yr.sia, na.rm = T),
                          max(sia.clean.02$yr.sia, na.rm = T),
                          sep = "_"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -4111,15 +4111,20 @@ s1_create_change_log <- function(polis_data_folder,
 #'
 #' @param polis_data_folder `str` Path to the POLIS data folder
 #' @param timestamp `str` Time stamp folder name
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns NULL
 #' @keywords internal
 #'
-s1_archive_old_files <- function(polis_data_folder, timestamp) {
+s1_archive_old_files <- function(polis_data_folder, timestamp, output_folder_name) {
 
   cli_process_start("Archiving old files")
   most_recent_files_01 <- s1_get_most_recent_files(polis_data_folder,
-                                                   c(".rds", ".csv", ".xlsx"))
+                                                   c(".rds", ".csv", ".xlsx"),
+                                                   output_folder_name)
 
   if (length(most_recent_files_01) > 0) {
     for (file in most_recent_files_01) {
@@ -4128,11 +4133,11 @@ s1_archive_old_files <- function(polis_data_folder, timestamp) {
       invisible(capture.output(
         tidypolis_io(
           io = "read",
-          file_path = file.path(polis_data_folder, "Core_Ready_Files", file)
+          file_path = file.path(polis_data_folder, output_folder_name, file)
         ) %>%
           tidypolis_io(
             io = "write",
-            file_path = file.path(polis_data_folder, "Core_Ready_Files", "Archive",
+            file_path = file.path(polis_data_folder, output_folder_name, "Archive",
                                   timestamp, file)
           )
       ))
@@ -4140,7 +4145,7 @@ s1_archive_old_files <- function(polis_data_folder, timestamp) {
       invisible(capture.output(
         tidypolis_io(
           io = "delete",
-          file_path = file.path(polis_data_folder, "Core_Ready_Files", file)
+          file_path = file.path(polis_data_folder, output_folder_name, file)
         )
       ))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -7235,36 +7235,42 @@ s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder, output_fo
 #' validation steps, including checking for duplicates, validating
 #' ES sites and checking against previous downloads
 #'
-#' @inheritParams preprocess_cdc
+#' @param polis_folder str: location of the POLIS data folder
 #' @param polis_data_folder `str` Path to the POLIS data folder.
 #' @param latest_folder_in_archive `str` Name of the latest folder in the archive.
-#'
-#' @returns `NULL` silently upon success.
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @export
-s4_fully_process_es_data <- function(polis_folder,
-                                     polis_data_folder = file.path(polis_folder, "data"),
-                                     latest_folder_in_archive){
+s4_fully_process_es_data <- function(
+    polis_folder,
+    polis_data_folder, latest_folder_in_archive,
+    output_folder_name){
 
-   if (!tidypolis_io(io = "exists.dir",
-                    file_path = file.path(polis_data_folder, "Core_Ready_Files"))) {
-     cli::cli_abort("Please run Step 1 and create a Core Ready folder before running this step.")
-   }
+  if (!tidypolis_io(io = "exists.dir",
+                    file_path = file.path(polis_data_folder, output_folder_name))) {
+    cli::cli_abort("Please run Step 1 and create a Core Ready folder before running this step.")
+  }
 
   es.05 <- s4_es_load_data(polis_data_folder = polis_data_folder,
-                           latest_folder_in_archive = latest_folder_in_archive) |>
-    s4_es_data_processing() |>
+                           latest_folder_in_archive = latest_folder_in_archive,
+                           output_folder_name = output_folder_name) |>
+    s4_es_data_processing(output_folder_name = output_folder_name) |>
     s4_es_validate_sites() |>
-    s4_es_create_cdc_vars(polis_folder = polis_folder)
+    s4_es_create_cdc_vars(
+      polis_folder = polis_folder,
+      output_folder_name = output_folder_name)
 
   s4_es_check_metadata(
     polis_data_folder = polis_data_folder,
-    es.05 = es.05,
+    es.05 = es.05, output_folder_name = output_folder_name,
     latest_folder_in_archive)
 
-
-  s4_es_write_data(polis_data_folder = polis_data_folder,
-                   es.05 = es.05)
+  s4_es_write_data(
+    polis_data_folder = polis_data_folder,
+    es.05 = es.05, output_folder_name = output_folder_name)
 
   rm("es.05")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3931,6 +3931,10 @@ s1_get_most_recent_files <- function(polis_data_folder, patterns,
 #' @param api_es_data `tibble` Cleaned ES data
 #' @param api_virus_data `tibble` Cleaned virus data
 #' @param api_subactivity_data `tibble` Cleaned subactivity data
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @returns `NULL`, if successful
 #' @keywords internal
@@ -3940,7 +3944,8 @@ s1_create_change_log <- function(polis_data_folder,
                                  api_case_data,
                                  api_es_data,
                                  api_virus_data,
-                                 api_subactivity_data) {
+                                 api_subactivity_data,
+                                 output_folder_name) {
 
   cli::cli_process_start(paste0("Processing data for: ", file))
   # compare current dataset to most recent and save summary to change_log
@@ -3948,7 +3953,7 @@ s1_create_change_log <- function(polis_data_folder,
     io = "read",
     file_path = file.path(
       polis_data_folder,
-      "Core_Ready_Files",
+      output_folder_name,
       file
     )
   ) |>
@@ -4076,7 +4081,7 @@ s1_create_change_log <- function(polis_data_folder,
     obj = change_summary,
     file_path = file.path(
       polis_data_folder,
-      "Core_Ready_Files",
+      output_folder_name,
       "Change Log",
       timestamp,
       paste0(substr(file, 1, nchar(file) - 4), ".rds")
@@ -4085,17 +4090,17 @@ s1_create_change_log <- function(polis_data_folder,
 
   invisible(capture.output(
     # Move most recent to archive
-    tidypolis_io(io = "read", file_path = file.path(polis_data_folder, "Core_Ready_Files", file)) |>
+    tidypolis_io(io = "read", file_path = file.path(polis_data_folder, output_folder_name, file)) |>
       tidypolis_io(
         io = "write",
-        file_path = file.path(polis_data_folder, "Core_Ready_Files", "Archive", timestamp, file)
+        file_path = file.path(polis_data_folder, output_folder_name, "Archive", timestamp, file)
       )
   ))
 
   invisible(capture.output(
 
     # Delete the original file
-    tidypolis_io(io = "delete", file_path = file.path(polis_data_folder, "Core_Ready_Files", file))
+    tidypolis_io(io = "delete", file_path = file.path(polis_data_folder, output_folder_name, file))
   ))
   cli_process_done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -8203,7 +8203,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder) {
 #' @returns `tibble` Cleaned positives dataset containing environmental samples only.
 #' @keywords internal
 #'
-s5_pos_process_es_virus <- function(virus.01, polis_data_folder) {
+s5_pos_process_es_virus <- function(virus.01, polis_data_folder, output_folder_name) {
 
   ### ENV data from virus table
   env.virus.01 <- virus.01 |>
@@ -8213,10 +8213,11 @@ s5_pos_process_es_virus <- function(virus.01, polis_data_folder) {
   cli::cli_process_start("Adding in ES data")
 
   # read in ES files from cleaned ENV linelist
-  env.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files"), full_names = T)) |>
-    dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/Core_Ready_Files/"), "")) |>
+  env.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, output_folder_name), full_names = T)) |>
+    dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/", output_folder_name, "/"), "")) |>
     dplyr::filter(grepl("^(es).*(.rds)$", short_name)) |>
     dplyr::pull(name)
+
   tryCatch({
     es.01 <- purrr::map_df(env.files.01, ~ tidypolis_io(io = "read", file_path = .x)) |>
       dplyr::ungroup() |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -4678,22 +4678,27 @@ s2_standardize_dates <- function(data) {
 #'
 #' @param data `tibble` A tibble containing AFP surveillance data
 #' @param polis_data_folder `str` String path to the POLIS data folder
+#' @param output_folder_name str: Name of the output directory where processed
+#'        files will be saved. Defaults to "Core_Ready_Files". For
+#'        region-specific processing, this should be set to
+#'        "Core_Ready_Files_[REGION]" (e.g., "Core_Ready_Files_AFRO").
 #'
 #' @return Invisibly returns the filtered data frame of records with missing
 #'    onset dates
 #' @export
-s2_export_missing_onsets <- function(data, polis_data_folder) {
+s2_export_missing_onsets <- function(data, polis_data_folder, output_folder_name) {
   missing_onsets <- data |>
     dplyr::select(epid, dateonset) |>
     dplyr::filter(is.na(dateonset))
 
-invisible(capture.output(
+  invisible(capture.output(
     tidypolis_io(
       io = "write",
       obj = missing_onsets,
-      file_path = paste0(polis_data_folder, "/Core_Ready_Files/afp_no_onset.csv")
+      file_path = paste0(polis_data_folder, "/",
+                         output_folder_name, "/afp_no_onset.csv")
     )
-))
+  ))
 
   cli::cli_alert_info(paste0(
     "Exported ", nrow(missing_onsets), " records with missing onset dates"

--- a/man/check_missingness.Rd
+++ b/man/check_missingness.Rd
@@ -4,12 +4,17 @@
 \alias{check_missingness}
 \title{Function to create summary of key variable missingness in CORE datafiles}
 \usage{
-check_missingness(data, type)
+check_missingness(data, type, output_folder_name)
 }
 \arguments{
 \item{data}{tibble the datatable for which we want to check key variable missingness}
 
 \item{type}{str "AFP", "ES", or "POS", type of dataset to check missingness}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 a function to assess key variable missingness

--- a/man/create_response_vars.Rd
+++ b/man/create_response_vars.Rd
@@ -4,7 +4,11 @@
 \alias{create_response_vars}
 \title{Creates a summary of SIA responses to cVDPV detections}
 \usage{
-create_response_vars(pos, polis_data_folder = Sys.getenv("POLIS_DATA_CACHE"))
+create_response_vars(
+  pos,
+  output_folder_name,
+  polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")
+)
 }
 \arguments{
 \item{pos}{\code{tibble} The positive viruses dataset.}

--- a/man/preprocess_cdc.Rd
+++ b/man/preprocess_cdc.Rd
@@ -4,10 +4,16 @@
 \alias{preprocess_cdc}
 \title{Preprocess data process data in the CDC style}
 \usage{
-preprocess_cdc(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"))
+preprocess_cdc(
+  polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
+  who_region = NULL
+)
 }
 \arguments{
 \item{polis_folder}{str: location of the POLIS data folder}
+
+\item{who_region}{str: optional WHO region to filter data
+Available inputs include AFRO, AMRO, EMRO, EURO, SEARO and  WPRO.}
 }
 \value{
 Outputs intermediary core ready files

--- a/man/preprocess_data.Rd
+++ b/man/preprocess_data.Rd
@@ -4,10 +4,13 @@
 \alias{preprocess_data}
 \title{Preprocess data retrieved from POLIS}
 \usage{
-preprocess_data(type)
+preprocess_data(type, who_region = NULL)
 }
 \arguments{
 \item{type}{str: specify the type of preprocessing to complete}
+
+\item{who_region}{str: optional WHO region to filter data
+Available inputs include AFRO, AMRO, EMRO, EURO, SEARO and  WPRO.}
 }
 \value{
 Analytic rds files

--- a/man/remove_character_dates.Rd
+++ b/man/remove_character_dates.Rd
@@ -7,7 +7,8 @@
 remove_character_dates(
   type,
   df,
-  polis_data_folder = Sys.getenv("POLIS_DATA_CACHE")
+  polis_data_folder = Sys.getenv("POLIS_DATA_CACHE"),
+  output_folder_name
 )
 }
 \arguments{
@@ -16,6 +17,11 @@ remove_character_dates(
 \item{df}{tibble: the dataframe from which to remove character formatted dates}
 
 \item{polis_data_folder}{str:  location of user's polis data folder}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 outputs a saved reference table of original date vars and a smaller

--- a/man/s1_archive_old_files.Rd
+++ b/man/s1_archive_old_files.Rd
@@ -4,12 +4,17 @@
 \alias{s1_archive_old_files}
 \title{Archives the old files in the data folder}
 \usage{
-s1_archive_old_files(polis_data_folder, timestamp)
+s1_archive_old_files(polis_data_folder, timestamp, output_folder_name)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder}
 
 \item{timestamp}{\code{str} Time stamp folder name}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 Archives the old files in the data folder

--- a/man/s1_create_change_log.Rd
+++ b/man/s1_create_change_log.Rd
@@ -11,7 +11,8 @@ s1_create_change_log(
   api_case_data,
   api_es_data,
   api_virus_data,
-  api_subactivity_data
+  api_subactivity_data,
+  output_folder_name
 )
 }
 \arguments{
@@ -28,6 +29,11 @@ s1_create_change_log(
 \item{api_virus_data}{\code{tibble} Cleaned virus data}
 
 \item{api_subactivity_data}{\code{tibble} Cleaned subactivity data}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{NULL}, if successful

--- a/man/s1_create_core_ready_dir.Rd
+++ b/man/s1_create_core_ready_dir.Rd
@@ -4,12 +4,17 @@
 \alias{s1_create_core_ready_dir}
 \title{Helper function to create Core Ready Archive and Change Log}
 \usage{
-s1_create_core_ready_dir(polis_data_folder, timestamp)
+s1_create_core_ready_dir(polis_data_folder, timestamp, output_folder_name)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Location of the POLIS data folder.}
 
 \item{timestamp}{\code{str} Folder name as the timestamp.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 Helper function to create Core Ready Archive and Change Log

--- a/man/s1_export_final_core_ready_files.Rd
+++ b/man/s1_export_final_core_ready_files.Rd
@@ -11,7 +11,8 @@ s1_export_final_core_ready_files(
   api_case_data,
   api_subactivity_data,
   api_es_data,
-  api_virus_data
+  api_virus_data,
+  output_folder_name
 )
 }
 \arguments{
@@ -28,6 +29,11 @@ s1_export_final_core_ready_files(
 \item{api_es_data}{\code{tibble} Cleaned ES table.}
 
 \item{api_virus_data}{\code{tibble} Cleaned Virus table.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{NULL}

--- a/man/s1_get_most_recent_files.Rd
+++ b/man/s1_get_most_recent_files.Rd
@@ -4,12 +4,15 @@
 \alias{s1_get_most_recent_files}
 \title{Gets the most recent files in the Core Ready folder}
 \usage{
-s1_get_most_recent_files(polis_data_folder, patterns)
+s1_get_most_recent_files(polis_data_folder, patterns, output_folder_name)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Location of the POLIS data folder.}
 
-\item{patterns}{\code{list} A list of patterns to select files.}
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{list} With names of the most recent files that matches the patterns.

--- a/man/s1_prep_polis_tables.Rd
+++ b/man/s1_prep_polis_tables.Rd
@@ -9,7 +9,8 @@ s1_prep_polis_tables(
   polis_data_folder,
   long.global.dist.01,
   ts,
-  timestamp
+  timestamp,
+  who_region
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ s1_prep_polis_tables(
 \item{ts}{\code{str} Time stamp from \code{\link[=Sys.time]{Sys.time()}}.}
 
 \item{timestamp}{\code{str} Formatted time stamp.}
+
+\item{who_region}{str: optional WHO region to filter data
+Available inputs include AFRO, AMRO, EMRO, EURO, SEARO and  WPRO.}
 }
 \value{
 \code{NULL} quietly upon success.

--- a/man/s2_check_duplicated_epids.Rd
+++ b/man/s2_check_duplicated_epids.Rd
@@ -4,12 +4,17 @@
 \alias{s2_check_duplicated_epids}
 \title{Check for Duplicated EPIDs in AFP Data}
 \usage{
-s2_check_duplicated_epids(data, polis_data_folder)
+s2_check_duplicated_epids(data, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{data}{A dataframe containing AFP surveillance data}
 
 \item{polis_data_folder}{String path to the POLIS data folder}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 Logical. TRUE if duplicates found, FALSE if no duplicates

--- a/man/s2_check_missingness.Rd
+++ b/man/s2_check_missingness.Rd
@@ -4,7 +4,7 @@
 \alias{s2_check_missingness}
 \title{Check missingness in key AFP variables}
 \usage{
-s2_check_missingness(data, type = "AFP", polis_data_folder)
+s2_check_missingness(data, type = "AFP", polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{data}{A data frame containing AFP surveillance data}
@@ -12,6 +12,11 @@ s2_check_missingness(data, type = "AFP", polis_data_folder)
 \item{type}{String indicating the type of data (e.g., "AFP")}
 
 \item{polis_data_folder}{String path to the POLIS data folder}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 Invisibly returns the missingness summary

--- a/man/s2_compare_with_archive.Rd
+++ b/man/s2_compare_with_archive.Rd
@@ -10,7 +10,8 @@ s2_compare_with_archive(
   latest_archive,
   col_afp_raw,
   start_year = 2020,
-  end_year = lubridate::year(Sys.Date())
+  end_year = lubridate::year(Sys.Date()),
+  output_folder_name
 )
 }
 \arguments{
@@ -25,6 +26,11 @@ s2_compare_with_archive(
 \item{start_year}{Integer. Start year for filtering (default: 2020)}
 
 \item{end_year}{Integer. End year for filtering (default: current year)}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 A list containing comparison results:

--- a/man/s2_export_afp_outputs.Rd
+++ b/man/s2_export_afp_outputs.Rd
@@ -4,7 +4,13 @@
 \alias{s2_export_afp_outputs}
 \title{Export AFP data and related outputs}
 \usage{
-s2_export_afp_outputs(data, latest_archive, polis_data_folder, col_afp_raw)
+s2_export_afp_outputs(
+  data,
+  latest_archive,
+  polis_data_folder,
+  col_afp_raw,
+  output_folder_name
+)
 }
 \arguments{
 \item{data}{A data frame containing processed AFP data}
@@ -14,6 +20,11 @@ s2_export_afp_outputs(data, latest_archive, polis_data_folder, col_afp_raw)
 \item{polis_data_folder}{String path to the POLIS data folder}
 
 \item{col_afp_raw}{Names of original columns for comparison}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 Invisibly returns NULL

--- a/man/s2_export_missing_onsets.Rd
+++ b/man/s2_export_missing_onsets.Rd
@@ -4,12 +4,17 @@
 \alias{s2_export_missing_onsets}
 \title{Export EPIDs with missing onset dates}
 \usage{
-s2_export_missing_onsets(data, polis_data_folder)
+s2_export_missing_onsets(data, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{data}{\code{tibble} A tibble containing AFP surveillance data}
 
 \item{polis_data_folder}{\code{str} String path to the POLIS data folder}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 Invisibly returns the filtered data frame of records with missing

--- a/man/s2_find_latest_archive.Rd
+++ b/man/s2_find_latest_archive.Rd
@@ -4,13 +4,18 @@
 \alias{s2_find_latest_archive}
 \title{Find Latest Archive in Core Ready Files}
 \usage{
-s2_find_latest_archive(polis_data_folder, timestamp)
+s2_find_latest_archive(polis_data_folder, timestamp, output_folder_name)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} specifying the path to the main
 data folder containing Core Ready Files}
 
 \item{timestamp}{\code{str} Time stamp}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{str} containing either the name of the most recent

--- a/man/s2_fully_process_afp_data.Rd
+++ b/man/s2_fully_process_afp_data.Rd
@@ -9,7 +9,8 @@ s2_fully_process_afp_data(
   polis_folder,
   long.global.dist.01,
   timestamp,
-  latest_folder_in_archive_path
+  latest_folder_in_archive_path,
+  output_folder_name
 )
 }
 \arguments{
@@ -24,6 +25,11 @@ validation.}
 \item{timestamp}{\code{str} Time stamp}
 
 \item{latest_folder_in_archive_path}{\code{str} The path to the latest archive folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 This function processes AFP data through multiple standardization and

--- a/man/s2_process_coordinates.Rd
+++ b/man/s2_process_coordinates.Rd
@@ -4,7 +4,12 @@
 \alias{s2_process_coordinates}
 \title{Process GPS coordinates for AFP cases}
 \usage{
-s2_process_coordinates(data, polis_data_folder, polis_folder)
+s2_process_coordinates(
+  data,
+  polis_data_folder,
+  polis_folder,
+  output_folder_name
+)
 }
 \arguments{
 \item{data}{\code{tibble} A data frame containing AFP data with admin GUIDs}
@@ -13,6 +18,11 @@ s2_process_coordinates(data, polis_data_folder, polis_folder)
 Core_Ready_Files.}
 
 \item{polis_folder}{\code{str} Path to the main POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 A tibble with processed coordinate data

--- a/man/s3_fully_process_sia_data.Rd
+++ b/man/s3_fully_process_sia_data.Rd
@@ -8,7 +8,8 @@ s3_fully_process_sia_data(
   long.global.dist.01,
   polis_data_folder,
   latest_folder_in_archive,
-  timestamp
+  timestamp,
+  output_folder_name
 )
 }
 \arguments{
@@ -20,6 +21,11 @@ validation.}
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
 
 \item{timestamp}{\code{str} The time stamp.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 This function processes SIA data through multiple standardization and

--- a/man/s3_sia_check_metadata.Rd
+++ b/man/s3_sia_check_metadata.Rd
@@ -5,7 +5,12 @@
 \title{Check SIA dataset metadata against the previous download for data type changes
 or new types of entries}
 \usage{
-s3_sia_check_metadata(sia.06, polis_data_folder, latest_folder_in_archive)
+s3_sia_check_metadata(
+  sia.06,
+  polis_data_folder,
+  latest_folder_in_archive,
+  output_folder_name
+)
 }
 \arguments{
 \item{sia.06}{\code{tibble} The latest SIA download with variables checked and
@@ -15,6 +20,11 @@ deduplicated}
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
 
 \item{latest_folder_in_archive}{\code{str} Time stamp of latest folder in archive}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 Check SIA dataset metadata against the previous download for data type changes

--- a/man/s3_sia_evaluate_unmatched_guids.Rd
+++ b/man/s3_sia_evaluate_unmatched_guids.Rd
@@ -4,12 +4,17 @@
 \alias{s3_sia_evaluate_unmatched_guids}
 \title{Evaluate SIA data with unmatched spatial data}
 \usage{
-s3_sia_evaluate_unmatched_guids(sia.05, polis_data_folder)
+s3_sia_evaluate_unmatched_guids(sia.05, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{sia.05}{\code{tibble} the output of s3_sia_check_guids()}
 
 \item{polis_data_folder}{The POLIS data folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{NULL} silently.

--- a/man/s3_sia_load_data.Rd
+++ b/man/s3_sia_load_data.Rd
@@ -4,12 +4,21 @@
 \alias{s3_sia_load_data}
 \title{Load SIA Data}
 \usage{
-s3_sia_load_data(polis_data_folder, latest_folder_in_archive)
+s3_sia_load_data(
+  polis_data_folder,
+  latest_folder_in_archive,
+  output_folder_name
+)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
 
 \item{latest_folder_in_archive}{\code{str} Time stamp of latest folder in archive}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{tiblle} sia.01.new - the latest SIA data quality checked for variable

--- a/man/s3_sia_merge_cluster_dates_final_data.Rd
+++ b/man/s3_sia_merge_cluster_dates_final_data.Rd
@@ -7,7 +7,8 @@
 s3_sia_merge_cluster_dates_final_data(
   sia.clean.01,
   polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
-  polis_data_folder = file.path(polis_folder, "data")
+  polis_data_folder = file.path(polis_folder, "data"),
+  output_folder_name
 )
 }
 \arguments{
@@ -16,6 +17,11 @@ s3_sia_merge_cluster_dates_final_data(
 \item{polis_folder}{\code{str} Path to the POLIS folder.}
 
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{NULL} silently.

--- a/man/s3_sia_write_precluster_data.Rd
+++ b/man/s3_sia_write_precluster_data.Rd
@@ -4,7 +4,7 @@
 \alias{s3_sia_write_precluster_data}
 \title{Write out SIA data}
 \usage{
-s3_sia_write_precluster_data(sia.06, polis_data_folder)
+s3_sia_write_precluster_data(sia.06, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{sia.06}{\code{tibble} The latest SIA download with variables checked and
@@ -12,6 +12,11 @@ against the last download, CDC variables created, GUIDs validated and
 deduplicated}
 
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 Write out SIA data

--- a/man/s4_es_check_metadata.Rd
+++ b/man/s4_es_check_metadata.Rd
@@ -4,7 +4,12 @@
 \alias{s4_es_check_metadata}
 \title{Compare ES outputs with metadata from previous output}
 \usage{
-s4_es_check_metadata(polis_data_folder, es.05, latest_folder_in_archive)
+s4_es_check_metadata(
+  polis_data_folder,
+  es.05,
+  output_folder_name,
+  latest_folder_in_archive
+)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
@@ -12,6 +17,11 @@ s4_es_check_metadata(polis_data_folder, es.05, latest_folder_in_archive)
 \item{es.05}{\code{tibble} The latest ES download with variables checked
 against the last download, variables validated and sites checked and
 CDC variables enforced}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
 }

--- a/man/s4_es_create_cdc_vars.Rd
+++ b/man/s4_es_create_cdc_vars.Rd
@@ -4,13 +4,18 @@
 \alias{s4_es_create_cdc_vars}
 \title{Convert variables in POLIS download to to cleaned outputs}
 \usage{
-s4_es_create_cdc_vars(es.02, polis_folder)
+s4_es_create_cdc_vars(es.02, polis_folder, output_folder_name)
 }
 \arguments{
 \item{es.02}{\code{tibble} The latest ES download with variables checked
 against the last download, variables validated and sites checked}
 
-\item{polis_folder}{str: location of the POLIS data folder}
+\item{polis_folder}{\code{str} Path to the main POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{tibble} es.05 SIA data with CDC variables enforced

--- a/man/s4_es_data_processing.Rd
+++ b/man/s4_es_data_processing.Rd
@@ -4,7 +4,7 @@
 \alias{s4_es_data_processing}
 \title{Convert variables in POLIS download to to cleaned outputs}
 \usage{
-s4_es_data_processing(es.01.new)
+s4_es_data_processing(es.01.new, startyr, endyr, output_folder_name)
 }
 \arguments{
 \item{es.01.new}{\code{tibble} The latest ES download with variables checked
@@ -13,6 +13,11 @@ against the last download}
 \item{startyr}{\code{int} The subset of years for which to process ES data}
 
 \item{endyr}{\code{int} The subset of years for which to process ES data}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{tibble} es.02 SIA data with outputs validated

--- a/man/s4_es_load_data.Rd
+++ b/man/s4_es_load_data.Rd
@@ -4,15 +4,24 @@
 \alias{s4_es_load_data}
 \title{Load and check ES data against previous downloads}
 \usage{
-s4_es_load_data(polis_data_folder, latest_folder_in_archive)
+s4_es_load_data(
+  polis_data_folder,
+  latest_folder_in_archive,
+  output_folder_name
+)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
 
-\item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
+\item{latest_folder_in_archive}{\code{str} Time stamp of latest folder in archive}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
-\code{tibble} es.01.new - the latest SIA data quality checked for variable
+\code{tiblle} es.01.new - the latest SIA data quality checked for variable
 stability against the last download if it exists
 }
 \description{

--- a/man/s4_es_write_data.Rd
+++ b/man/s4_es_write_data.Rd
@@ -4,7 +4,7 @@
 \alias{s4_es_write_data}
 \title{Write out final ES data}
 \usage{
-s4_es_write_data(polis_data_folder, es.05)
+s4_es_write_data(polis_data_folder, es.05, output_folder_name)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
@@ -12,6 +12,11 @@ s4_es_write_data(polis_data_folder, es.05)
 \item{es.05}{\code{tibble} The latest ES download with variables checked
 against the last download, variables validated and sites checked and
 CDC variables enforced}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \value{
 \code{NULL} invisible return with write out to logs if necessary

--- a/man/s4_fully_process_es_data.Rd
+++ b/man/s4_fully_process_es_data.Rd
@@ -6,8 +6,9 @@
 \usage{
 s4_fully_process_es_data(
   polis_folder,
-  polis_data_folder = file.path(polis_folder, "data"),
-  latest_folder_in_archive
+  polis_data_folder,
+  latest_folder_in_archive,
+  output_folder_name
 )
 }
 \arguments{
@@ -16,9 +17,11 @@ s4_fully_process_es_data(
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
-}
-\value{
-\code{NULL} silently upon success.
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").}
 }
 \description{
 This function processes ES data through multiple standardization and

--- a/man/s5_fully_process_pos_data.Rd
+++ b/man/s5_fully_process_pos_data.Rd
@@ -8,7 +8,8 @@ s5_fully_process_pos_data(
   polis_folder,
   latest_folder_in_archive,
   long.global.dist.01,
-  polis_data_folder = file.path(polis_folder, "data")
+  polis_data_folder = file.path(polis_folder, "data"),
+  output_folder_name
 )
 }
 \arguments{
@@ -18,7 +19,13 @@ s5_fully_process_pos_data(
 
 \item{long.global.dist.01}{\code{sf} Global district lookup table for GUID}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
 validation.}
 }
 \value{

--- a/man/s5_pos_check_duplicates.Rd
+++ b/man/s5_pos_check_duplicates.Rd
@@ -4,12 +4,18 @@
 \alias{s5_pos_check_duplicates}
 \title{Check for duplicate entries in the virus table}
 \usage{
-s5_pos_check_duplicates(virus.01, polis_data_folder)
+s5_pos_check_duplicates(virus.01, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
 validation.}
 }
 \value{

--- a/man/s5_pos_compare_with_archive.Rd
+++ b/man/s5_pos_compare_with_archive.Rd
@@ -8,7 +8,8 @@ s5_pos_compare_with_archive(
   afp.es.virus.01,
   afp.es.virus.03,
   polis_data_folder,
-  latest_folder_in_archive
+  latest_folder_in_archive,
+  output_folder_name
 )
 }
 \arguments{
@@ -17,10 +18,16 @@ s5_pos_compare_with_archive(
 \item{afp.es.virus.03}{\code{tibble} Output of \code{\link[=s5_pos_create_final_virus]{s5_pos_create_final_virus()}} but processed
 further using \code{\link[=remove_character_dates]{remove_character_dates()}} and \code{\link[=create_response_vars]{create_response_vars()}}.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
-validation.}
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive, if one exists.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
+validation.}
 }
 \value{
 \code{NULL} quietly upon success.

--- a/man/s5_pos_create_cdc_vars.Rd
+++ b/man/s5_pos_create_cdc_vars.Rd
@@ -11,8 +11,7 @@ s5_pos_create_cdc_vars(virus.raw.new, polis_folder, polis_data_folder)
 
 \item{polis_folder}{\code{str} Path to the main POLIS folder.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
-validation.}
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
 }
 \value{
 \code{tibble} Raw virus data with additional CDC columns.

--- a/man/s5_pos_load_data.Rd
+++ b/man/s5_pos_load_data.Rd
@@ -4,13 +4,23 @@
 \alias{s5_pos_load_data}
 \title{Loads the most recent positives dataset}
 \usage{
-s5_pos_load_data(polis_data_folder, latest_folder_in_archive)
+s5_pos_load_data(
+  polis_data_folder,
+  latest_folder_in_archive,
+  output_folder_name
+)
 }
 \arguments{
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
-validation.}
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive, if one exists.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
+validation.}
 }
 \value{
 \code{tibble} New virus dataset.

--- a/man/s5_pos_process_es_virus.Rd
+++ b/man/s5_pos_process_es_virus.Rd
@@ -4,12 +4,18 @@
 \alias{s5_pos_process_es_virus}
 \title{Process and clean cases in the positives dataset}
 \usage{
-s5_pos_process_es_virus(virus.01, polis_data_folder)
+s5_pos_process_es_virus(virus.01, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
 validation.}
 }
 \value{

--- a/man/s5_pos_process_human_virus.Rd
+++ b/man/s5_pos_process_human_virus.Rd
@@ -4,12 +4,18 @@
 \alias{s5_pos_process_human_virus}
 \title{Process and clean cases in the positives dataset}
 \usage{
-s5_pos_process_human_virus(virus.01, polis_data_folder)
+s5_pos_process_human_virus(virus.01, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
 validation.}
 
 \item{startyr}{\code{int} Start year to process the positives dataset.}

--- a/man/s5_pos_write_missing_onsets.Rd
+++ b/man/s5_pos_write_missing_onsets.Rd
@@ -4,12 +4,18 @@
 \alias{s5_pos_write_missing_onsets}
 \title{Obtain positives records with missing onset date}
 \usage{
-s5_pos_write_missing_onsets(virus.01, polis_data_folder)
+s5_pos_write_missing_onsets(virus.01, polis_data_folder, output_folder_name)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
-\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
+\item{polis_data_folder}{\code{str} The data folder within the POLIS folder.}
+
+\item{output_folder_name}{str: Name of the output directory where processed
+files will be saved. Defaults to "Core_Ready_Files". For
+region-specific processing, this should be set to
+"Core_Ready_Files_\link{REGION}" (e.g., "Core_Ready_Files_AFRO").
+
 validation.}
 }
 \value{


### PR DESCRIPTION
This PR adds region-specific filtering to the preprocessing function by creating separate `Core_Ready_Files_<REGION>` folders when a region is specified, while keeping the default as `Core_Ready_Files` when no region is set. This ensures cache consistency across runs and avoids mixing outputs from different regions. It also adds basic validation to check for potential cache inconsistencies.

## Changes

**1) Added who_region Parameter**
- `preprocess_cdc()` and `preprocess_data()` now accept `who_region` param
- Creates corresponding `Core_Ready_Files_<REGION>` folder when region specified

**2) Propagation of output_folder_name Parameter**
- Adds output_folder_name parameter to downstream functions for correct output handling
- Ensures consistent cache folder usage throughout pipeline

**3) WHO Region Column Tracking**
- Adds WHORegion to cleaned activity and sub-activity datasets via 
  `s1_clean_activity_table()` and `s1_clean_subactivity_table()`
- Enables downstream filtering by region

**4) Column Existence Checks**
- Updates `s3_sia_check_duplicates()` to select only existing columns
- Handles missing optional columns (e.g., children.inaccessible) in regions like AMRO

**5) ADM2GUID Type Conflict Fix**
- Resolves type conflict in `s3_sia_check_guids()`

**6) Missing Non-AFP File Handling**
- Gracefully handles absent surveillance types (e.g., contact surveillance in AMRO)
- Skips missing data with appropriate warning messages

All changes maintain backward compatibility while adding new functionality. Testing 
completed successfully across most regions.

Closes #178 (Add data filtering capability to preprocess_cdc)