### PR TITLE
195 Add control over output file format in preprocess cdc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Suggests:
     tidyselect,
     stats,
     utils,
+    arrow,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)

--- a/R/dal.R
+++ b/R/dal.R
@@ -169,7 +169,7 @@ tidypolis_io <- function(
       }
 
       if (grepl("\\.parquet$", file_path)) {
-        arrow::write_parquet(file_path)
+        arrow::write_parquet(obj, file_path)
       }
     }
   }

--- a/R/dal.R
+++ b/R/dal.R
@@ -133,7 +133,7 @@ tidypolis_io <- function(
       }
 
       if (grepl("\\.parquet$", file_path)) {
-        arrow::read_parquet(file_path)
+        return(arrow::read_parquet(file_path))
       }
 
     }

--- a/R/dal.R
+++ b/R/dal.R
@@ -129,7 +129,7 @@ tidypolis_io <- function(
       }
 
       if (grepl("\\.csv$", file_path)) {
-        return(readr::read_csv(file_path))
+        return(readr::read_csv(file_path, show_col_types = FALSE))
       }
     }
   }

--- a/R/init.R
+++ b/R/init.R
@@ -389,6 +389,10 @@ freeze_polis_data <- function(){
 #' @description
 #' Create standard analytic datasets from raw POLIS data
 #' @param type str: specify the type of preprocessing to complete
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
+#'
 #' @import cli
 #' @returns Analytic rds files
 #' @examples
@@ -396,7 +400,7 @@ freeze_polis_data <- function(){
 #' preprocess_data(type = "cdc") #must run init_tidypolis to specify POLIS data location first
 #' }
 #' @export
-preprocess_data <- function(type){
+preprocess_data <- function(type, output_format){
 
   types <- c("cdc")
 
@@ -407,7 +411,7 @@ preprocess_data <- function(type){
   #CDC pre-processing steps
   if(type == "cdc"){
 
-    preprocess_cdc()
+    preprocess_cdc(output_format = output_format)
 
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2248,7 +2248,8 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
 
   cli::cli_h1("Step 4/5 - Creating ES analytic datasets")
 
-  s4_fully_process_es_data(polis_data_folder = polis_data_folder,
+  s4_fully_process_es_data(polis_folder = polis_folder,
+                           polis_data_folder = polis_data_folder,
                            latest_folder_in_archive = latest_folder_in_archive,
                            output_format = output_format)
 
@@ -5745,7 +5746,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     file_path = paste0(polis_data_folder, "/core_files_to_combine"),
     full_names = TRUE
   )) |>
-    dplyr::filter(grepl(paste0("^.*(afp_linelist).*(\\", output_format, ")$"), name)) |>
+    dplyr::filter(grepl("^.*(afp_linelist).*(.rds)$", name)) |>
     dplyr::pull(name)
 
   # Combine AFP files
@@ -5859,7 +5860,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
       file_path = paste0(polis_data_folder, "/core_files_to_combine"),
       full_names = TRUE
     )) |>
-      dplyr::filter(grepl(paste0("^.*(other_surveillance).*(\\", output_format, ")$"), name)) |>
+      dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
       dplyr::pull(name)
 
     # Combine other surveillance files
@@ -6147,14 +6148,14 @@ s3_fully_process_sia_data <- function(long.global.dist.01, polis_data_folder,
                                output_format = output_format)
 
   #final clean dataset
-  sia.clean.01 <- s3_sia_combine_historical_data(sia.new = sia.06, polis_data_folder)
+  sia.clean.01 <- s3_sia_combine_historical_data(sia.new = sia.06,
+                                                 polis_data_folder)
 
   #creates cache from clustered SIA dates
   s3_sia_cluster_dates(sia.clean.01)
 
   #merged data with clustered data
-  s3_sia_merge_cluster_dates_final_data(sia.clean.01 = sia.clean.01,
-                                        output_format = output_format)
+  s3_sia_merge_cluster_dates_final_data(sia.clean.01 = sia.clean.01)
 
   #evaluate unmatched GUIDs
   s3_sia_evaluate_unmatched_guids(sia.05 = sia.05, polis_data_folder)
@@ -6672,14 +6673,11 @@ s3_sia_write_precluster_data <- function(sia.06, polis_data_folder, output_forma
 #' against the last download, CDC variables created, GUIDs validated and
 #' deduplicated
 #' @param polis_data_folder `str` Path to the POLIS data folder.
-#' @param output_format str: output_format to save files as.
-#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
-#'    'rds'.
 #'
 #' @returns `tibble` sia.clean.01 All historical SIA data
 #' @keywords internal
 #'
-s3_sia_combine_historical_data <- function(sia.new, polis_data_folder, output_format){
+s3_sia_combine_historical_data <- function(sia.new, polis_data_folder){
 
   #combine SIA pre-2020 with the current rds
   # read SIA and combine to make one SIA dataset
@@ -6688,7 +6686,7 @@ s3_sia_combine_historical_data <- function(sia.new, polis_data_folder, output_fo
     "name" = tidypolis_io(io = "list",
                           file_path=paste0(polis_data_folder, "/core_files_to_combine"),
                           full_names=TRUE)) |>
-    dplyr::filter(grepl(paste0("^.*(sia).*(\\", output_format, ")$"), name)) |>
+    dplyr::filter(grepl("^.*(sia).*(.rds)$", name)) |>
     dplyr::pull(name)
 
   invisible(capture.output(

--- a/R/utils.R
+++ b/R/utils.R
@@ -2249,7 +2249,9 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
   #Step 5 - Creating Virus datasets ====
   cli::cli_h1("Step 5/5 - Creating Virus datasets")
 
-  s5_fully_process_pos_data(polis_folder, latest_folder_in_archive, long.global.dist.01)
+  s5_fully_process_pos_data(polis_folder, latest_folder_in_archive,
+                            long.global.dist.01,
+                            output_format = output_format)
 
   update_polis_log(.event = "Processing of CORE datafiles complete",
                    .event_type = "END")
@@ -7684,13 +7686,18 @@ s4_es_write_data <- function(polis_data_folder, es.05, output_format){
 #' @param long.global.dist.01 `sf` Global district lookup table for GUID
 #' @param polis_data_folder `str` The data folder within the POLIS folder.
 #'   validation.
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
+#'
 #' @returns `NULL` quietly upon success.
 #'
 #' @export
 s5_fully_process_pos_data <- function(polis_folder,
                                       latest_folder_in_archive,
                                       long.global.dist.01,
-                                      polis_data_folder = file.path(polis_folder, "data")) {
+                                      polis_data_folder = file.path(polis_folder, "data"),
+                                      output_format) {
 
   virus.raw.new <- s5_pos_load_data(polis_data_folder, latest_folder_in_archive)
   virus.01 <- s5_pos_create_cdc_vars(virus.raw.new, polis_folder, polis_data_folder)
@@ -7698,8 +7705,10 @@ s5_fully_process_pos_data <- function(polis_folder,
   s5_pos_check_duplicates(virus.01, polis_data_folder)
   s5_pos_write_missing_onsets(virus.01, polis_data_folder)
 
-  human.virus.05 <- s5_pos_process_human_virus(virus.01, polis_data_folder)
-  env.virus.04 <- s5_pos_process_es_virus(virus.01, polis_data_folder)
+  human.virus.05 <- s5_pos_process_human_virus(virus.01, polis_data_folder,
+                                               output_format = output_format)
+  env.virus.04 <- s5_pos_process_es_virus(virus.01, polis_data_folder,
+                                          output_format = output_format)
 
   afp.es.virus.01 <- s5_pos_create_final_virus_data(human.virus.05, env.virus.04)
   afp.es.virus.02 <- remove_character_dates(type = "POS", df = afp.es.virus.01)
@@ -7708,7 +7717,8 @@ s5_fully_process_pos_data <- function(polis_folder,
   rm(afp.es.virus.02)
 
   s5_pos_compare_with_archive(afp.es.virus.01, afp.es.virus.03,
-                              polis_data_folder, latest_folder_in_archive)
+                              polis_data_folder, latest_folder_in_archive,
+                              output_format = output_format)
 
   s5_pos_evaluate_unmatched_guids(afp.es.virus.03, long.global.dist.01, polis_data_folder)
 
@@ -8022,11 +8032,15 @@ s5_pos_write_missing_onsets <- function(virus.01, polis_data_folder) {
 #' @inheritParams s5_pos_check_duplicates
 #' @param startyr `int` Start year to process the positives dataset.
 #' @param endyr `int` End year to process the positives dataset.
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @returns `tibble` Cleaned positives dataset containing human cases only.
 #' @keywords internal
 #'
-s5_pos_process_human_virus <- function(virus.01, polis_data_folder) {
+s5_pos_process_human_virus <- function(virus.01, polis_data_folder,
+                                       output_format) {
 
   startyr <- 2000
   endyr <- year(format(Sys.time()))
@@ -8039,7 +8053,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder) {
   cli::cli_process_start("Processing and cleaning AFP/non-AFP files")
   afp.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files"), full_names = T)) |>
     dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/Core_Ready_Files/"), "")) |>
-    dplyr::filter(grepl("^(afp_linelist_2001-01-01_2025).*(.rds)$", short_name)) |>
+    dplyr::filter(grepl(paste0("^(afp_linelist_2001-01-01_2025).*(\\", output_format, ")$"), short_name)) |>
     dplyr::pull(name)
 
   tryCatch({
@@ -8054,7 +8068,8 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder) {
 
   non.afp.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files"), full_names = T)) |>
     dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/Core_Ready_Files/"), "")) |>
-    dplyr::filter(grepl("^(other_surveillance_type_linelist_2016_2025).*(.rds)$", short_name)) |>
+    dplyr::filter(grepl(paste0("^(other_surveillance_type_linelist_2016_2025).*(\\",
+                               output_format, ")$"), short_name)) |>
     dplyr::pull(name)
 
   tryCatch({
@@ -8149,11 +8164,15 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder) {
 #'
 #'
 #' @inheritParams s5_pos_check_duplicates
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @returns `tibble` Cleaned positives dataset containing environmental samples only.
 #' @keywords internal
 #'
-s5_pos_process_es_virus <- function(virus.01, polis_data_folder) {
+s5_pos_process_es_virus <- function(virus.01, polis_data_folder,
+                                    output_format) {
 
   ### ENV data from virus table
   env.virus.01 <- virus.01 |>
@@ -8165,7 +8184,7 @@ s5_pos_process_es_virus <- function(virus.01, polis_data_folder) {
   # read in ES files from cleaned ENV linelist
   env.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, "Core_Ready_Files"), full_names = T)) |>
     dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/Core_Ready_Files/"), "")) |>
-    dplyr::filter(grepl("^(es).*(.rds)$", short_name)) |>
+    dplyr::filter(grepl(paste0("^.*(es).*(\\", output_format, ")$"), short_name)) |>
     dplyr::pull(name)
   tryCatch({
     es.01 <- purrr::map_df(env.files.01, ~ tidypolis_io(io = "read", file_path = .x)) |>
@@ -8284,11 +8303,14 @@ s5_pos_create_final_virus_data <- function(human.virus.05, env.virus.04) {
 #' @param afp.es.virus.03 `tibble` Output of [s5_pos_create_final_virus()] but processed
 #' further using [remove_character_dates()] and [create_response_vars()].
 #' @inheritParams s5_fully_process_pos_data
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @returns `NULL` quietly upon success.
 #' @keywords internal
 #'
-s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_data_folder, latest_folder_in_archive) {
+s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_data_folder, latest_folder_in_archive, output_format) {
   cli::cli_process_start("Checking for variables that don't match last weeks pull")
 
   #Compare the final file to last week's final file to identify any differences in var_names, var_classes, or categorical responses
@@ -8413,7 +8435,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
                                        max(afp.es.virus.03$dateonset, na.rm = T),
                                        sep = "_"
                                  ),
-                                 ".rds",
+                                 output_format,
                                  sep = ""
                ))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -8193,12 +8193,20 @@ s5_pos_process_es_virus <- function(virus.01, polis_data_folder,
     dplyr::filter(grepl(paste0("^.*(es).*(\\", output_format, ")$"), short_name)) |>
     dplyr::pull(name)
   tryCatch({
-    es.01 <- purrr::map_df(env.files.01, ~ tidypolis_io(io = "read", file_path = .x)) |>
-      dplyr::ungroup() |>
-      dplyr::distinct(.keep_all = T)
+    es.01 <- purrr::map_df(env.files.01, \(x) {
+      df <- tidypolis_io(io = "read", file_path = x)
+      if ("Admin 0 Id" %in% names(df)) {
+        df <- df |>
+          dplyr::mutate(`Admin 0 Id` = as.character(`Admin 0 Id`),
+                        `Admin 1 Id` = as.character(`Admin 1 Id`),
+                        `Admin 2 Id` = as.character(`Admin 2 Id`))
+      }
+      df
+    }) |> dplyr::ungroup()
   }, error = \(e) {
     cli::cli_abort("Please run Step 4 of preprocessing before Step 5.")
   })
+
 
   # Make sure 'env.sample.maual.edit.id' is unique for each ENV sample
   es.00 <- es.01[duplicated(es.01$env.sample.manual.edit.id), ]

--- a/R/utils.R
+++ b/R/utils.R
@@ -2243,7 +2243,8 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
   cli::cli_h1("Step 4/5 - Creating ES analytic datasets")
 
   s4_fully_process_es_data(polis_data_folder = polis_data_folder,
-                           latest_folder_in_archive = latest_folder_in_archive)
+                           latest_folder_in_archive = latest_folder_in_archive,
+                           output_format = output_format)
 
   #Step 5 - Creating Virus datasets ====
   cli::cli_h1("Step 5/5 - Creating Virus datasets")
@@ -7059,13 +7060,17 @@ s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder){
 #' @inheritParams preprocess_cdc
 #' @param polis_data_folder `str` Path to the POLIS data folder.
 #' @param latest_folder_in_archive `str` Name of the latest folder in the archive.
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @returns `NULL` silently upon success.
 #'
 #' @export
 s4_fully_process_es_data <- function(polis_folder,
                                      polis_data_folder = file.path(polis_folder, "data"),
-                                     latest_folder_in_archive){
+                                     latest_folder_in_archive,
+                                     output_format){
 
    if (!tidypolis_io(io = "exists.dir",
                     file_path = file.path(polis_data_folder, "Core_Ready_Files"))) {
@@ -7085,7 +7090,8 @@ s4_fully_process_es_data <- function(polis_folder,
 
 
   s4_es_write_data(polis_data_folder = polis_data_folder,
-                   es.05 = es.05)
+                   es.05 = es.05,
+                   output_format = output_format)
 
   rm("es.05")
 
@@ -7631,11 +7637,14 @@ s4_es_check_metadata <- function(polis_data_folder, es.05,
 #' @param es.05 `tibble` The latest ES download with variables checked
 #' against the last download, variables validated and sites checked and
 #' CDC variables enforced
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @returns `NULL` invisible return with write out to logs if necessary
 #' @keywords internal
 #'
-s4_es_write_data <- function(polis_data_folder, es.05){
+s4_es_write_data <- function(polis_data_folder, es.05, output_format){
 
   cli::cli_process_start("Writing out ES datasets")
 
@@ -7648,7 +7657,7 @@ s4_es_write_data <- function(polis_data_folder, es.05){
         "/Core_Ready_Files/",
         paste("es", min(es.05$collect.date, na.rm = T),
               max(es.05$collect.date, na.rm = T), sep = "_"),
-        ".rds",
+        output_format,
         sep = ""
       ))
   ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -7087,7 +7087,7 @@ s4_fully_process_es_data <- function(polis_folder,
 
   es.05 <- s4_es_load_data(polis_data_folder = polis_data_folder,
                            latest_folder_in_archive = latest_folder_in_archive) |>
-    s4_es_data_processing() |>
+    s4_es_data_processing(polis_data_folder = polis_data_folder) |>
     s4_es_validate_sites() |>
     s4_es_create_cdc_vars(polis_folder = polis_folder)
 
@@ -7214,11 +7214,13 @@ s4_es_load_data <- function(polis_data_folder, latest_folder_in_archive){
 #' against the last download
 #' @param startyr `int` The subset of years for which to process ES data
 #' @param endyr `int` The subset of years for which to process ES data
+#' @inheritParams s4_fully_process_es_data
 #'
 #' @returns `tibble` es.02 SIA data with outputs validated
 #' @keywords internal
 #'
-s4_es_data_processing <- function(es.01.new){
+s4_es_data_processing <- function(es.01.new,
+                                  polis_data_folder){
 
   # Data manipulation
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2217,7 +2217,8 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
     polis_folder = polis_folder,
     long.global.dist.01 = long.global.dist.01,
     timestamp = timestamp,
-    latest_folder_in_archive_path = latest_folder_in_archive)
+    latest_folder_in_archive_path = latest_folder_in_archive,
+    output_format = output_format)
 
   invisible(gc())
 
@@ -4224,11 +4225,14 @@ s1_export_final_core_ready_files <- function(polis_data_folder, ts, timestamp,
 #'   validation.
 #' @param timestamp `str` Time stamp
 #' @param latest_folder_in_archive_path `str` The path to the latest archive folder.
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @export
 s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
                                       long.global.dist.01, timestamp,
-                                      latest_folder_in_archive_path) {
+                                      latest_folder_in_archive_path, output_format) {
 
   if (!tidypolis_io(io = "exists.dir",
                     file_path = file.path(polis_data_folder, "Core_Ready_Files"))) {
@@ -4311,7 +4315,8 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
     data = afp_final,
     latest_archive = latest_folder_in_archive_path,
     polis_data_folder = polis_data_folder,
-    col_afp_raw = colnames(afp_raw_new)
+    col_afp_raw = colnames(afp_raw_new),
+    output_format = output_format
   )
 
 }
@@ -5599,11 +5604,14 @@ s2_create_afp_variables <- function(data) {
 #' @param latest_archive String containing the name of the latest archive folder
 #' @param polis_data_folder String path to the POLIS data folder
 #' @param col_afp_raw Names of original columns for comparison
+#' @param output_format str: output_format to save files as.
+#'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+#'    'rds'.
 #'
 #' @return Invisibly returns NULL
 #' @export
 s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
-                                  col_afp_raw) {
+                                  col_afp_raw, output_format) {
 
   cli::cli_process_start("Exporting AFP outputs",
                          msg_done = "Exported AFP outputs")
@@ -5682,7 +5690,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         file_path = paste0(
           polis_data_folder, "/Core_Ready_Files/afp_linelist_",
           min(afp_data$dateonset, na.rm = TRUE), "_",
-          max(afp_data$dateonset, na.rm = TRUE), ".rds"
+          max(afp_data$dateonset, na.rm = TRUE), output_format
         )
       )
   ))
@@ -5703,7 +5711,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
         file_path = paste0(
           polis_data_folder, "/Core_Ready_Files/afp_lat_long_",
           min(afp_latlong$dateonset, na.rm = TRUE), "_",
-          max(afp_latlong$dateonset, na.rm = TRUE), ".csv"
+          max(afp_latlong$dateonset, na.rm = TRUE), output_format
         )
       )
   ))
@@ -5719,7 +5727,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     file_path = paste0(polis_data_folder, "/Core_Ready_Files"),
     full_names = TRUE
   )) |>
-    dplyr::filter(grepl("^.*(afp_linelist).*(.rds)$", name)) |>
+    dplyr::filter(grepl(paste0("^.*(afp_linelist).*(\\", output_format, ")$"), name)) |>
     dplyr::pull(name)
 
   afp_files_combine <- dplyr::tibble("name" = tidypolis_io(
@@ -5727,7 +5735,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
     file_path = paste0(polis_data_folder, "/core_files_to_combine"),
     full_names = TRUE
   )) |>
-    dplyr::filter(grepl("^.*(afp_linelist).*(.rds)$", name)) |>
+    dplyr::filter(grepl(paste0("^.*(afp_linelist).*(\\", output_format, ")$"), name)) |>
     dplyr::pull(name)
 
   # Combine AFP files
@@ -5767,7 +5775,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
           min(afp_combined$dateonset, na.rm = TRUE),
           "_",
           max(afp_combined$dateonset, na.rm = TRUE),
-          ".rds"
+          output_format
         )
       )
     ))
@@ -5788,7 +5796,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
           min(afp_light$dateonset, na.rm = TRUE),
           "_",
           max(afp_light$dateonset, na.rm = TRUE),
-          ".rds"
+          output_format
         )
       )
     ))
@@ -5818,7 +5826,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
           polis_data_folder,
           "/Core_Ready_Files/other_surveillance_type_linelist_",
           min(other_surv$yronset, na.rm = TRUE), "_",
-          max(other_surv$yronset, na.rm = TRUE), ".rds"
+          max(other_surv$yronset, na.rm = TRUE), output_format
         )
       )
     ))
@@ -5833,7 +5841,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
       file_path = paste0(polis_data_folder, "/Core_Ready_Files"),
       full_names = TRUE
     )) |>
-      dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
+      dplyr::filter(grepl(paste0("^.*(other_surveillance).*(\\", output_format, ")$"), name)) |>
       dplyr::pull(name)
 
     other_files_combine <- dplyr::tibble("name" = tidypolis_io(
@@ -5841,7 +5849,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
       file_path = paste0(polis_data_folder, "/core_files_to_combine"),
       full_names = TRUE
     )) |>
-      dplyr::filter(grepl("^.*(other_surveillance).*(.rds)$", name)) |>
+      dplyr::filter(grepl(paste0("^.*(other_surveillance).*(\\", output_format, ")$"), name)) |>
       dplyr::pull(name)
 
     # Combine other surveillance files
@@ -5883,7 +5891,7 @@ s2_export_afp_outputs <- function(data, latest_archive, polis_data_folder,
             min(other_combined$yronset, na.rm = TRUE),
             "_",
             max(other_combined$yronset, na.rm = TRUE),
-            ".rds"
+            output_format
           )
         )
       ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -2101,8 +2101,14 @@ check_missingness <- function(data,
 preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
                            output_format = "rds") {
 
+
+  # ensure leading dot in output_format
+  if (!startsWith(output_format, ".")) {
+    output_format <- paste0(".", output_format)
+  }
+
   # validate output_format
-  if (!output_format %in% c("rds", "rda", "csv", "parquet")) {
+  if (!output_format %in% c(".rds", ".rda", ".csv", ".parquet")) {
     stop("Currently, only 'rds', 'rda', 'csv', and 'parquet' are supported.")
   }
 

--- a/man/preprocess_cdc.Rd
+++ b/man/preprocess_cdc.Rd
@@ -4,10 +4,17 @@
 \alias{preprocess_cdc}
 \title{Preprocess data process data in the CDC style}
 \usage{
-preprocess_cdc(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"))
+preprocess_cdc(
+  polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
+  output_format = "rds"
+)
 }
 \arguments{
 \item{polis_folder}{str: location of the POLIS data folder}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 Outputs intermediary core ready files

--- a/man/preprocess_data.Rd
+++ b/man/preprocess_data.Rd
@@ -4,10 +4,14 @@
 \alias{preprocess_data}
 \title{Preprocess data retrieved from POLIS}
 \usage{
-preprocess_data(type)
+preprocess_data(type, output_format)
 }
 \arguments{
 \item{type}{str: specify the type of preprocessing to complete}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 Analytic rds files

--- a/man/s1_archive_old_files.Rd
+++ b/man/s1_archive_old_files.Rd
@@ -4,12 +4,16 @@
 \alias{s1_archive_old_files}
 \title{Archives the old files in the data folder}
 \usage{
-s1_archive_old_files(polis_data_folder, timestamp)
+s1_archive_old_files(polis_data_folder, timestamp, output_format)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder}
 
 \item{timestamp}{\code{str} Time stamp folder name}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \description{
 Archives the old files in the data folder

--- a/man/s1_export_final_core_ready_files.Rd
+++ b/man/s1_export_final_core_ready_files.Rd
@@ -11,7 +11,8 @@ s1_export_final_core_ready_files(
   api_case_data,
   api_subactivity_data,
   api_es_data,
-  api_virus_data
+  api_virus_data,
+  output_format
 )
 }
 \arguments{
@@ -28,6 +29,10 @@ s1_export_final_core_ready_files(
 \item{api_es_data}{\code{tibble} Cleaned ES table.}
 
 \item{api_virus_data}{\code{tibble} Cleaned Virus table.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL}

--- a/man/s1_prep_polis_tables.Rd
+++ b/man/s1_prep_polis_tables.Rd
@@ -9,7 +9,8 @@ s1_prep_polis_tables(
   polis_data_folder,
   long.global.dist.01,
   ts,
-  timestamp
+  timestamp,
+  output_format
 )
 }
 \arguments{
@@ -22,6 +23,10 @@ s1_prep_polis_tables(
 \item{ts}{\code{str} Time stamp from \code{\link[=Sys.time]{Sys.time()}}.}
 
 \item{timestamp}{\code{str} Formatted time stamp.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL} quietly upon success.

--- a/man/s2_export_afp_outputs.Rd
+++ b/man/s2_export_afp_outputs.Rd
@@ -4,7 +4,13 @@
 \alias{s2_export_afp_outputs}
 \title{Export AFP data and related outputs}
 \usage{
-s2_export_afp_outputs(data, latest_archive, polis_data_folder, col_afp_raw)
+s2_export_afp_outputs(
+  data,
+  latest_archive,
+  polis_data_folder,
+  col_afp_raw,
+  output_format
+)
 }
 \arguments{
 \item{data}{A data frame containing processed AFP data}
@@ -14,6 +20,10 @@ s2_export_afp_outputs(data, latest_archive, polis_data_folder, col_afp_raw)
 \item{polis_data_folder}{String path to the POLIS data folder}
 
 \item{col_afp_raw}{Names of original columns for comparison}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 Invisibly returns NULL

--- a/man/s2_fully_process_afp_data.Rd
+++ b/man/s2_fully_process_afp_data.Rd
@@ -9,7 +9,8 @@ s2_fully_process_afp_data(
   polis_folder,
   long.global.dist.01,
   timestamp,
-  latest_folder_in_archive_path
+  latest_folder_in_archive_path,
+  output_format
 )
 }
 \arguments{
@@ -24,6 +25,10 @@ validation.}
 \item{timestamp}{\code{str} Time stamp}
 
 \item{latest_folder_in_archive_path}{\code{str} The path to the latest archive folder.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \description{
 This function processes AFP data through multiple standardization and

--- a/man/s3_fully_process_sia_data.Rd
+++ b/man/s3_fully_process_sia_data.Rd
@@ -8,7 +8,8 @@ s3_fully_process_sia_data(
   long.global.dist.01,
   polis_data_folder,
   latest_folder_in_archive,
-  timestamp
+  timestamp,
+  output_format
 )
 }
 \arguments{
@@ -20,6 +21,10 @@ validation.}
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
 
 \item{timestamp}{\code{str} The time stamp.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \description{
 This function processes SIA data through multiple standardization and

--- a/man/s3_sia_combine_historical_data.Rd
+++ b/man/s3_sia_combine_historical_data.Rd
@@ -4,10 +4,14 @@
 \alias{s3_sia_combine_historical_data}
 \title{Read in SIA data pre 2020 and combine with current SIA data}
 \usage{
-s3_sia_combine_historical_data(sia.new, polis_data_folder)
+s3_sia_combine_historical_data(sia.new, polis_data_folder, output_format)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 
 \item{sia.06}{\code{tibble} The latest SIA download with variables checked and
 against the last download, CDC variables created, GUIDs validated and

--- a/man/s3_sia_write_precluster_data.Rd
+++ b/man/s3_sia_write_precluster_data.Rd
@@ -4,7 +4,7 @@
 \alias{s3_sia_write_precluster_data}
 \title{Write out SIA data}
 \usage{
-s3_sia_write_precluster_data(sia.06, polis_data_folder)
+s3_sia_write_precluster_data(sia.06, polis_data_folder, output_format)
 }
 \arguments{
 \item{sia.06}{\code{tibble} The latest SIA download with variables checked and
@@ -12,6 +12,10 @@ against the last download, CDC variables created, GUIDs validated and
 deduplicated}
 
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \description{
 Write out SIA data

--- a/man/s4_es_write_data.Rd
+++ b/man/s4_es_write_data.Rd
@@ -4,7 +4,7 @@
 \alias{s4_es_write_data}
 \title{Write out final ES data}
 \usage{
-s4_es_write_data(polis_data_folder, es.05)
+s4_es_write_data(polis_data_folder, es.05, output_format)
 }
 \arguments{
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
@@ -12,6 +12,10 @@ s4_es_write_data(polis_data_folder, es.05)
 \item{es.05}{\code{tibble} The latest ES download with variables checked
 against the last download, variables validated and sites checked and
 CDC variables enforced}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL} invisible return with write out to logs if necessary

--- a/man/s4_fully_process_es_data.Rd
+++ b/man/s4_fully_process_es_data.Rd
@@ -7,7 +7,8 @@
 s4_fully_process_es_data(
   polis_folder,
   polis_data_folder = file.path(polis_folder, "data"),
-  latest_folder_in_archive
+  latest_folder_in_archive,
+  output_format
 )
 }
 \arguments{
@@ -16,6 +17,10 @@ s4_fully_process_es_data(
 \item{polis_data_folder}{\code{str} Path to the POLIS data folder.}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL} silently upon success.

--- a/man/s5_fully_process_pos_data.Rd
+++ b/man/s5_fully_process_pos_data.Rd
@@ -8,7 +8,8 @@ s5_fully_process_pos_data(
   polis_folder,
   latest_folder_in_archive,
   long.global.dist.01,
-  polis_data_folder = file.path(polis_folder, "data")
+  polis_data_folder = file.path(polis_folder, "data"),
+  output_format
 )
 }
 \arguments{
@@ -20,6 +21,10 @@ s5_fully_process_pos_data(
 
 \item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
 validation.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL} quietly upon success.

--- a/man/s5_pos_compare_with_archive.Rd
+++ b/man/s5_pos_compare_with_archive.Rd
@@ -8,7 +8,8 @@ s5_pos_compare_with_archive(
   afp.es.virus.01,
   afp.es.virus.03,
   polis_data_folder,
-  latest_folder_in_archive
+  latest_folder_in_archive,
+  output_format
 )
 }
 \arguments{
@@ -21,6 +22,10 @@ further using \code{\link[=remove_character_dates]{remove_character_dates()}} an
 validation.}
 
 \item{latest_folder_in_archive}{\code{str} Name of the latest folder in the archive, if one exists.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{NULL} quietly upon success.

--- a/man/s5_pos_process_es_virus.Rd
+++ b/man/s5_pos_process_es_virus.Rd
@@ -4,13 +4,17 @@
 \alias{s5_pos_process_es_virus}
 \title{Process and clean cases in the positives dataset}
 \usage{
-s5_pos_process_es_virus(virus.01, polis_data_folder)
+s5_pos_process_es_virus(virus.01, polis_data_folder, output_format)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
 \item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
 validation.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 }
 \value{
 \code{tibble} Cleaned positives dataset containing environmental samples only.

--- a/man/s5_pos_process_human_virus.Rd
+++ b/man/s5_pos_process_human_virus.Rd
@@ -4,13 +4,17 @@
 \alias{s5_pos_process_human_virus}
 \title{Process and clean cases in the positives dataset}
 \usage{
-s5_pos_process_human_virus(virus.01, polis_data_folder)
+s5_pos_process_human_virus(virus.01, polis_data_folder, output_format)
 }
 \arguments{
 \item{virus.01}{\code{tibble} Output of \code{\link[=s5_pos_create_cdc_vars]{s5_pos_create_cdc_vars()}}.}
 
 \item{polis_data_folder}{\code{str} The data folder within the POLIS folder.
 validation.}
+
+\item{output_format}{str: output_format to save files as.
+Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
+'rds'.}
 
 \item{startyr}{\code{int} Start year to process the positives dataset.}
 


### PR DESCRIPTION
This PR introduces an output_format argument to `preprocess_cdc()` and `preprocess_data()`, defaulting to "rds" for backward compatibility. This gives users control over the file format used for output.

```
# Default behavior (rds)
preprocess_cdc(polis_folder = "01_data/data")

# Optional parquet output
preprocess_cdc(polis_folder = "01_data/data", output_format = "parquet")

```
The changes apply to all downstream modular functions within `preprocess_cdc` that handle reading or writing POLIS data; the `output_format` parameter is passed through consistently within these functions.

I have tested the changes locally and confirmed they work as expected. I have also updated the function documentation to reflect the new output_format argument.



