### PR TITLE
206 optimize preprocess cdc function for speed

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -8800,7 +8800,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
     in_old_not_new <- old |>
       dplyr::filter(!(epid %in% new$epid))
 
-    in_new_and_old_but_modified <- new |>
+    in_new_and_old_but_modified <- suppressWarnings({ new |>
       dplyr::filter(epid %in% old$epid) |>
       dplyr::select(-c(setdiff(colnames(new), colnames(old)))) |>
       setdiff(old |>
@@ -8816,6 +8816,7 @@ s5_pos_compare_with_archive <- function(afp.es.virus.01, afp.es.virus.03, polis_
       dplyr::mutate(name = stringr::str_sub(name, 1, -3)) |>
       #long_to_wide
       tidyr::pivot_wider(names_from=source, values_from=value)
+    })
 
     if(nrow(in_new_and_old_but_modified) > 0){
       in_new_and_old_but_modified <- in_new_and_old_but_modified |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -1804,7 +1804,8 @@ remove_character_dates <- function(type,
 
     df.02 <- df |>
       dplyr::select(env.sample.manual.edit.id, env.sample.id, !(dplyr::contains("date") & dplyr::where(is.character))) |>
-      dplyr::left_join(df.01.fixed)
+      dplyr::left_join(df.01.fixed,
+                       by = c("env.sample.manual.edit.id", "env.sample.id"))
 
   }
 
@@ -7866,11 +7867,16 @@ s4_es_create_cdc_vars <- function(es.02, polis_folder, output_folder_name){
                              })
   ))
 
-  sf::sf_use_s2(F)
-  shape.name.01 <- global.ctry.01 |>
-    dplyr::select(ISO_3_CODE, ADM0_NAME.rep = ADM0_NAME) |>
-    dplyr::distinct(.keep_all = T)
-  sf::sf_use_s2(T)
+  suppressMessages(
+    suppressWarnings({
+      sf::sf_use_s2(FALSE)
+      shape.name.01 <- global.ctry.01 |>
+        dplyr::select(ISO_3_CODE, ADM0_NAME.rep = ADM0_NAME) |>
+        dplyr::distinct(.keep_all = T)
+      sf::sf_use_s2(FALSE)
+    }
+    )
+  )
 
   savescipen <- getOption("scipen")
   options(scipen = 999)

--- a/R/utils.R
+++ b/R/utils.R
@@ -2286,7 +2286,8 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
     timestamp = timestamp,
     latest_folder_in_archive_path = latest_folder_in_archive,
     output_folder_name = output_folder_name,
-    output_format = output_format)
+    output_format = output_format,
+    archive = archive)
 
   invisible(gc())
 
@@ -4444,12 +4445,15 @@ s2_trim_archives <- function(polis_data_folder, output_folder_name, keep_n = 3) 
 #' @param output_format str: output_format to save files as.
 #'    Available formats include 'rds' 'rda' 'csv' and 'parquet', Defaults is
 #'    'rds'.
+#' @param archive Logical. Whether to archive previous output directories
+#'    before overwriting. Default is `TRUE`.
 #'
 #' @export
 s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
                                       long.global.dist.01, timestamp,
                                       latest_folder_in_archive_path,
-                                      output_folder_name, output_format) {
+                                      output_folder_name, output_format,
+                                      archive) {
 
   if (!tidypolis_io(io = "exists.dir",
                     file_path = file.path(polis_data_folder, output_folder_name))) {
@@ -4537,7 +4541,7 @@ s2_fully_process_afp_data <- function(polis_data_folder, polis_folder,
     col_afp_raw = colnames(afp_raw_new),
     output_folder_name = output_folder_name,
     output_format = output_format,
-    archive
+    archive = archive
   )
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1089,7 +1089,7 @@ remove_empty_columns <- function(dataframe) {
   }
   return(
     original_df |>
-      dplyr::select(-empty_cols)
+      dplyr::select(-dplyr::all_of(empty_cols))
   )
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1371,10 +1371,10 @@ f.pre.stsample.01 <- function(df01, global.dist.01) {
     empty.coord.01 <- empty.coord |>
       tibble::as_tibble() |>
       dplyr::group_by(Admin2GUID) |>
-      dplyr::summarise(nperarm = dplyr::n()) |>
+      dplyr::summarise(nperarm = dplyr::n(),
+                       .groups = "drop") |>
       dplyr::arrange(Admin2GUID) |>
       dplyr::mutate(id = dplyr::row_number()) |>
-      dplyr::ungroup() |>
       dplyr::filter(Admin2GUID != "{NA}")
 
     empty.coord.02 <- global.dist.01 |>
@@ -2043,7 +2043,8 @@ check_missingness <- function(data,
 
     missing_by_group <- data |>
       dplyr::select("yronset", "place.admin.0", dplyr::any_of(afp.vars)) |>
-      dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100), .by = c("yronset", "place.admin.0")) |>
+      dplyr::summarise(dplyr::across(dplyr::everything(), ~ mean(is.na(.)) * 100),
+                       .by = c("yronset", "place.admin.0")) |>
       dplyr::filter(dplyr::if_any(dplyr::any_of(afp.vars), ~ . >= 10))
 
     invisible(capture.output(
@@ -2878,7 +2879,8 @@ process_spatial <- function(gdb_folder,
   if(endyr == lubridate::year(format(Sys.time())) & startyr == 2000) {
     prov.shape.issue.01 <- long.global.prov.01 |>
       dplyr::group_by(ADM0_NAME, ADM1_NAME, active.year.01) |>
-      dplyr::summarise(no.of.shapes = dplyr::n()) |>
+      dplyr::summarise(no.of.shapes = dplyr::n(),
+                       .groups = "drop") |>
       dplyr::filter(no.of.shapes > 1)
 
     if(edav) {
@@ -2919,7 +2921,8 @@ process_spatial <- function(gdb_folder,
   if(endyr == year(format(Sys.time())) & startyr == 2000) {
     dist.shape.issue.01 <- long.global.dist.01 |>
       dplyr::group_by(ADM0_NAME, ADM1_NAME, ADM2_NAME, active.year.01) |>
-      dplyr::summarise(no.of.shapes = dplyr::n()) |>
+      dplyr::summarise(no.of.shapes = dplyr::n(),
+                       .groups = "drop") |>
       dplyr::filter(no.of.shapes > 1)
 
     if(edav) {
@@ -2985,10 +2988,10 @@ add_gpei_cases <- function(azcontainer = suppressMessages(get_azure_storage_conn
     proxy.data.fill.prov.01 <- proxy.data.fill.prov |>
       tibble::as_tibble() |>
       dplyr::group_by(adm1guid) |>
-      dplyr::summarise(nperarm = dplyr::n()) |>
+      dplyr::summarise(nperarm = dplyr::n(),
+                       .groups = "drop") |>
       dplyr::arrange(adm1guid) |>
       dplyr::mutate(id = dplyr::row_number()) |>
-      dplyr::ungroup() |>
       dplyr::filter(adm1guid != "{NA}")
 
     proxy.data.fill.prov.02 <- global.prov |>
@@ -3082,10 +3085,10 @@ add_gpei_cases <- function(azcontainer = suppressMessages(get_azure_storage_conn
     proxy.data.fill.ctry.01 <- proxy.data.fill.ctry |>
       tibble::as_tibble() |>
       dplyr::group_by(adm0guid) |>
-      dplyr::summarise(nperarm = dplyr::n()) |>
+      dplyr::summarise(nperarm = dplyr::n(),
+                       .groups = "drop") |>
       dplyr::arrange(adm0guid) |>
       dplyr::mutate(id = dplyr::row_number()) |>
-      dplyr::ungroup() |>
       dplyr::filter(adm0guid != "{NA}")
 
     proxy.data.fill.ctry.02 <- global.ctry |>
@@ -4115,14 +4118,14 @@ s1_create_change_log <- function(polis_data_folder,
 
   potential_duplicates_new <- new |>
     dplyr::group_by(Id) |>
-    dplyr::summarise(count = n()) |>
-    dplyr::ungroup() |>
+    dplyr::summarise(count = n(),
+                     .groups = "drop") |>
     dplyr::filter(count >= 2)
 
   potential_duplicates_old <- old |>
     dplyr::group_by(Id) |>
-    dplyr::summarise(count = n()) |>
-    dplyr::ungroup() |>
+    dplyr::summarise(count = n(),
+                     .groups = "drop") |>
     dplyr::filter(count >= 2)
 
   new <- new |>
@@ -7365,7 +7368,7 @@ s3_sia_evaluate_unmatched_guids <- function(sia.05, polis_data_folder, output_fo
 
   cty.yr.mismatch <- dist.sia.mismatch.01 |>
     dplyr::group_by(place.admin.0, yr.sia) |>
-    dplyr::summarise(no.of.mismatch.sia = n())
+    dplyr::summarise(no.of.mismatch.sia = n(), .groups = "drop")
 
   # excel file summarizing mismatch SIA by country
 
@@ -7736,7 +7739,8 @@ s4_es_data_processing <- function(es.01.new,
 
   es.space.03 <- es.space.02 |>
     dplyr::group_by(env.sample.manual.edit.id) |>
-    dplyr::summarise(virus.type.01 = paste(virus.type, collapse = ", "))
+    dplyr::summarise(virus.type.01 = paste(virus.type, collapse = ", "),
+                     .groups = "drop")
 
   es.space.03$virus.type.01[es.space.03$virus.type.01=="NA"] <- NA
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1893,7 +1893,7 @@ create_response_vars <- function(pos,
                   time.to.response <= 180) |>
     unique()
 
-  finished.responses <- rbind(type1, type2, type3) |>
+  finished.responses <- dplyr::bind_rows(type1, type2, type3) |>
     dplyr::group_by(epid, ntchanges, emergencegroup) |>
     dplyr::mutate(finished.responses = n()) |>
     dplyr::ungroup() |>
@@ -2877,7 +2877,7 @@ process_spatial <- function(gdb_folder,
     df.list[[i]] <- df02
   }
 
-  long.global.prov.01 <- do.call(rbind, df.list)
+  long.global.prov.01 <- dplyr::bind_rows(df.list)
   cli::cli_process_start("Evaluating overlapping province shapes")
 
   if(endyr == lubridate::year(format(Sys.time())) & startyr == 2000) {
@@ -2917,7 +2917,7 @@ process_spatial <- function(gdb_folder,
     df.list[[i]] <- df02
   }
 
-  long.global.dist.01 <- do.call(rbind, df.list)
+  long.global.dist.01 <- dplyr::bind_rows(df.list)
 
   cli::cli_process_start("Evaluating overlapping district shapes")
 
@@ -3173,7 +3173,7 @@ add_gpei_cases <- function(azcontainer = suppressMessages(get_azure_storage_conn
   }
 
   if(exists("proxy.data.prov.final") & exists("proxy.data.ctry.final")) {
-    proxy.data.final <- rbind(proxy.data.prov.final, proxy.data.ctry.final) |>
+    proxy.data.final <- dplyr::bind_rows(proxy.data.prov.final, proxy.data.ctry.final) |>
       dplyr::mutate(dateonset = as.Date(dateonset, format = "%m/%d/%Y"),
                     report_date = as.Date(report_date, format = "%m/%d/%Y"),
                     latitude = as.character(latitude),
@@ -5625,7 +5625,7 @@ s2_process_coordinates <- function(data, polis_data_folder, polis_folder,
     data_deduped <- dup_epid_fixed |>
       dplyr::select(-c("epid", "dup_epid")) |>
       dplyr::rename(epid = epid_fixed) |>
-      rbind(data_renamed |> filter(!epid %in% dup_epid_fixed$epid))
+      dplyr::bind_rows(data_renamed |> filter(!epid %in% dup_epid_fixed$epid))
 
 
     cli::cli_alert_warning(paste0(
@@ -8523,7 +8523,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
 
 
   #Combine AFP and other surveillance type cases
-  afp.02 <- rbind(afp.01, non.afp.01) |>
+  afp.02 <- dplyr::bind_rows(afp.01, non.afp.01) |>
     dplyr::select(epid, lat, lon, datenotificationtohq) |>
     dplyr::mutate(datenotificationtohq = parse_date_time(datenotificationtohq, c("%Y-%m-%d", "%d/%m/%Y")))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -5596,9 +5596,13 @@ s2_process_coordinates <- function(data, polis_data_folder, polis_folder,
     dplyr::bind_rows(dup_epid_01)
 
     for (i in 1:nrow(dup_epid_fixed |> dplyr::filter(!is.na(epid_fixed)))) {
-      update_polis_log(.event = paste0("Duplicate EPID ", dup_epid_fixed[i, "epid"], " updated to: ",
+
+      suppressMessages(
+      update_polis_log(.event = paste0("Duplicate EPID ",
+                                       dup_epid_fixed[i, "epid"], " updated to: ",
                                        dup_epid_fixed[i, "epid_fixed"]),
                        .event_type = "ALERT")
+      )
     }
 
     data_deduped <- dup_epid_fixed |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -3336,9 +3336,6 @@ s1_prep_polis_tables <- function(polis_folder, polis_data_folder,
       dplyr::filter(`WHO Region` == who_region)
     cli::cli_alert_success(
       paste0("Filtered case data to region: ", who_region))
-  } else {
-    cli::cli_alert_warning(
-      "Could not find WHO region column in case data. No filtering applied.")
   }
 
   cli::cli_h2("Environmental Samples")
@@ -3352,9 +3349,6 @@ s1_prep_polis_tables <- function(polis_folder, polis_data_folder,
       dplyr::filter(`WHO Region` == who_region)
     cli::cli_alert_success(
       paste0("Filtered ES data to region: ", who_region))
-  } else {
-    cli::cli_alert_warning(
-      "Could not find WHO region column in ES data. No filtering applied.")
   }
 
   cli::cli_h2("Virus")
@@ -3367,9 +3361,6 @@ s1_prep_polis_tables <- function(polis_folder, polis_data_folder,
       dplyr::filter(`WHO Region` == who_region)
     cli::cli_alert_success(
       paste0("Filtered Virus data to region: ", who_region))
-  } else {
-    cli::cli_alert_warning(
-      "Could not find WHO region column in Virus data. No filtering applied.")
   }
 
   cli::cli_h2("Activity")
@@ -3384,9 +3375,6 @@ s1_prep_polis_tables <- function(polis_folder, polis_data_folder,
       dplyr::filter(`WHORegion` == who_region)
     cli::cli_alert_success(
       paste0("Filtered Activity data to region: ", who_region))
-  } else {
-    cli::cli_alert_warning(
-      "Could not find WHO region column in Activity data. No filtering applied.")
   }
 
   cli::cli_h2("Sub-activity")
@@ -3402,9 +3390,6 @@ s1_prep_polis_tables <- function(polis_folder, polis_data_folder,
       dplyr::filter(WHORegion == who_region)
     cli::cli_alert_success(
       paste0("Filtered Sub-activity data to region: ", who_region))
-  } else {
-    cli::cli_alert_warning(
-      "Could not find WHO region column in Sub-activity data. No filtering applied.")
   }
 
   rm(crosswalk_data)


### PR DESCRIPTION
In this PR I managed to improve the speed of `preprocess_cdc()` by applying several refactorings. Most importantly, I moved `st_make_valid()` out of Step 2 and into `process_spatial()`, so validity checks only run once during preprocessing of new shapefiles.


As a result, the function now runs in just under 10, this for global POLIS data. The remaining bottlenecks are in Steps 2 and 5, where we load, save, and bind the large AFP datasets. These steps should speed up considerably if we decide to drop unnecessary raw columns and convert strings to factors, as we discussed recently @mcuadera.
 
I also cleaned up console output so that `preprocess_cdc()` produces concise, informative CLI messages rather than verbose logs or warnings.

Closes #206 