### PR TITLE
tidyselect deprecation warning in remove_empty_columns() #245

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1140,7 +1140,7 @@ remove_empty_columns <- function(dataframe) {
   }
   return(
     original_df |>
-      dplyr::select(-empty_cols)
+      dplyr::select(-dplyr::any_of(empty_cols))
   )
 }
 


### PR DESCRIPTION
Fixed tidyselect deprecation warning by wrapping `empty_cols` with `any_of()` in `select()`.