### PR TITLE
Make historical RDS data optional when running preprocessing 

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -100,7 +100,7 @@ init_tidypolis <- function(
       "Following required files not found in the misc folder: ",
       paste0(missing_files, collapse = ", ")
     ))
-    cli::cli_alert_abort("Required files missing")
+    cli::cli_abort("Please request these files from the CDC PEB SIR Team")
   } else {
     cli::cli_alert_success("All required files present!")
   }

--- a/R/init.R
+++ b/R/init.R
@@ -100,7 +100,7 @@ init_tidypolis <- function(
       "Following required files not found in the misc folder: ",
       paste0(missing_files, collapse = ", ")
     ))
-    cli::cli_alert_warning("Required files missing")
+    cli::cli_alert_abort("Required files missing")
   } else {
     cli::cli_alert_success("All required files present!")
   }

--- a/R/init.R
+++ b/R/init.R
@@ -100,7 +100,7 @@ init_tidypolis <- function(
       "Following required files not found in the misc folder: ",
       paste0(missing_files, collapse = ", ")
     ))
-    cli::cli_abort("Please request these files from the CDC PEB SIR Team")
+    cli::cli_alert_warning("Required files missing")
   } else {
     cli::cli_alert_success("All required files present!")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1370,15 +1370,16 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
   missing_static_files <- check_missing_static_files(core_files_folder_path)
   if (length(missing_static_files) > 0) {
     cli::cli_alert_warning(paste0(
-      "The following file(s) are missing from:", core_files_folder_path,
-
+      "Please request the following file(s) from the SIR team",
+      "and move them into: ", core_files_folder_path
     ))
     for (file in missing_static_files) {
-      cli::cli_alert_info(file)
+      cli::cli_alert_info(paste0(file, "\n"))
     }
-
+    cli::cli_alert_warning("Continuing execution of preprocessing with missing files.")
   }
   rm(core_files_folder_path, missing_static_files)
+
 
   # Step 1 - Basic cleaning and crosswalk ======
   cli::cli_h1("Step 1/5: Basic cleaning and crosswalk across datasets")

--- a/R/utils.R
+++ b/R/utils.R
@@ -933,14 +933,30 @@ create_response_vars <- function(pos,
   # bring in processed SIA data
   path <- tidypolis_io(io = "list", file_path = file.path(Sys.getenv("POLIS_DATA_CACHE"), output_folder_name), full_names = T)
 
+  sia <- NULL
+  sia_path <- path[grepl("sia_2000", path)]
+
+  if (length(sia_path) > 0) {
   tryCatch(
     {
       sia <- tidypolis_io(io = "read", file_path = path[grepl("sia_2000", path)])
     },
     error = \(e) {
-      cli::cli_abort("Please run Step 3 of preprocessing before Step 5.")
+      sia <- NULL
     }
   )
+
+  # If no SIA data, return pos unchanged with NA response variables
+  if (is.null(sia)) {
+    cli::cli_warn("No SIA file found.")
+    pos_with_nas <- pos |>
+      dplyr::mutate(
+        finished.responses = NA_real_,
+        planned.campaigns = NA_real_,
+        ipv.campaigns = NA_real_
+      )
+    return(pos_with_nas)
+  }
 
   sia.sub <- sia |>
     dplyr::select(
@@ -7989,6 +8005,8 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
     dplyr::filter(grepl(paste0("^(afp_linelist_2001-01-01).*(\\", output_format, ")$"), short_name)) |>
     dplyr::pull(name)
 
+  afp.01 <- NULL
+  if (length(afp.files.01) > 0) {
   tryCatch(
     {
       afp.01 <- lapply(afp.files.01, function(x) tidypolis_io(io = "read", file_path = x)) |>
@@ -7998,10 +8016,10 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
         dplyr::filter(dplyr::between(yronset, startyr, endyr))
     },
     error = \(e) {
-      cli::cli_abort("Please run Step 2 of preprocessing before Step 5.")
+      cli::cli_warn("Please run Step 2 of preprocessing before Step 5.")
     }
   )
-
+}
 
   non.afp.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, output_folder_name), full_names = T)) |>
     dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/", output_folder_name, "/"), "")) |>
@@ -8011,7 +8029,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
     ), short_name)) |>
     dplyr::pull(name)
 
-
+  non.afp.01 <- NULL
   if (output_folder_name == "Core_Ready_Files" ||
     length(non.afp.files.01) > 0) {
     tryCatch(
@@ -8025,7 +8043,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
           dplyr::filter(dplyr::between(yronset, startyr, endyr))
       },
       error = \(e) {
-        cli::cli_abort("Please run Step 2 of preprocessing before Step 5.")
+        cli::cli_warn("Non-AFP surveillance files found but could not be read")
       }
     )
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -933,16 +933,14 @@ create_response_vars <- function(pos,
   # bring in processed SIA data
   path <- tidypolis_io(io = "list", file_path = file.path(Sys.getenv("POLIS_DATA_CACHE"), output_folder_name), full_names = T)
 
-  sia <- NULL
-  sia_path <- path[grepl("sia_2000", path)]
 
-  if (length(sia_path) > 0) {
   tryCatch(
     {
       sia <- tidypolis_io(io = "read", file_path = path[grepl("sia_2000", path)])
     },
     error = \(e) {
-      sia <- NULL
+      cli::cli_warn("sia_2000 missing...continuing.")
+
     }
   )
 
@@ -8005,8 +8003,7 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
     dplyr::filter(grepl(paste0("^(afp_linelist_2001-01-01).*(\\", output_format, ")$"), short_name)) |>
     dplyr::pull(name)
 
-  afp.01 <- NULL
-  if (length(afp.files.01) > 0) {
+
   tryCatch(
     {
       afp.01 <- lapply(afp.files.01, function(x) tidypolis_io(io = "read", file_path = x)) |>
@@ -8016,10 +8013,9 @@ s5_pos_process_human_virus <- function(virus.01, polis_data_folder, output_folde
         dplyr::filter(dplyr::between(yronset, startyr, endyr))
     },
     error = \(e) {
-      cli::cli_warn("Please run Step 2 of preprocessing before Step 5.")
-    }
-  )
-}
+      cli::cli_warn("Missing other_surveillance_type_linelist_2016...continuing.")
+     }
+    )
 
   non.afp.files.01 <- dplyr::tibble("name" = tidypolis_io(io = "list", file_path = file.path(polis_data_folder, output_folder_name), full_names = T)) |>
     dplyr::mutate(short_name = stringr::str_replace(name, paste0(polis_data_folder, "/", output_folder_name, "/"), "")) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -1370,13 +1370,13 @@ preprocess_cdc <- function(polis_folder = Sys.getenv("POLIS_DATA_FOLDER"),
   missing_static_files <- check_missing_static_files(core_files_folder_path)
   if (length(missing_static_files) > 0) {
     cli::cli_alert_warning(paste0(
-      "Please request the following file(s) from the SIR team",
-      "and move them into: ", core_files_folder_path
+      "The following file(s) are missing from:", core_files_folder_path,
+
     ))
     for (file in missing_static_files) {
-      cli::cli_alert_info(paste0(file, "\n"))
+      cli::cli_alert_info(file)
     }
-    cli::cli_abort("Halting execution of preprocessing due to missing files.")
+
   }
   rm(core_files_folder_path, missing_static_files)
 


### PR DESCRIPTION
Updated init.R to give a warning if historical data files are not present instead of aborting.