### PR TITLE
Add step to check for contacts that are classified as afp

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -2842,6 +2842,49 @@ s1_clean_case_table <- function(path, crosswalk,
   api_case_sub3 <- remove_empty_columns(api_case_sub3)
   cli::cli_process_done()
 
+  cli::cli_process_start("Checking for Contact epids classified as AFP")
+  #Temporary location (Will update to edav location)
+  output_dir <- "C:/Users/uhx0/Downloads/afp_contacts_count.csv"  # change later
+
+  afp_contacts_count<- api_case_sub3 |>
+    dplyr::mutate(
+      Year = lubridate::year(as.Date(.data[["Case Date"]])),
+      EPID = as.character(EPID),
+      Stool2_chr = trimws(as.character(.data[["Stool 2 Collection Date"]]))
+    ) |>
+    dplyr::filter(
+      .data[["Surveillance Type"]] == "AFP",
+      stringr::str_detect(
+        EPID,
+        stringr::regex("(HC\\d+|CC\\d+|C\\d+)$", ignore_case = TRUE)
+      ),
+      is.na(.data[["Stool 2 Collection Date"]]) | Stool2_chr == ""
+    ) |>
+    dplyr::select(
+      `Place Admin 0`,
+      Year,
+      EPID,
+      `Surveillance Type`,
+      `Case Date`,
+      `Stool 1 Collection Date`,
+      `Stool 2 Collection Date`
+    ) |>
+    dplyr::arrange(`Place Admin 0`, Year, EPID)
+
+  if (nrow(afp_contacts_count) > 0) {
+    output_file <- file.path(
+      output_dir,
+      paste0("afp_contacts_count", format(Sys.Date(), "%Y-%m-%d"), ".csv")
+    )
+    readr::write_csv(afp_contacts_count, output_file)
+    cli::cli_alert_warning(paste0(
+      "AFP check: Found ", nrow(afp_contacts_count),
+      " records. CSV saved to: ", output_file
+    ))
+  } else {
+    cli::cli_alert_success("AFP check: No matches found.")
+  }
+
   return(api_case_sub3)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2856,7 +2856,8 @@ s1_clean_case_table <- function(path, crosswalk,
         EPID,
         stringr::regex("(HC\\d+|CC\\d+|C\\d+)$", ignore_case = TRUE)
       ),
-      is.na(.data[["Stool 2 Collection Date"]]) | Stool2_chr == ""
+      is.na(.data[["Stool 2 Collection Date"]]) | Stool2_chr == "",
+      !is.na(.data[["Paralysis Onset Date"]])
     ) |>
     dplyr::select(
       `Place Admin 0`,

--- a/R/utils.R
+++ b/R/utils.R
@@ -2843,8 +2843,6 @@ s1_clean_case_table <- function(path, crosswalk,
   cli::cli_process_done()
 
   cli::cli_process_start("Checking for Contact epids classified as AFP")
-  #Temporary location (Will update to edav location)
-  output_dir <- "C:/Users/uhx0/Downloads/afp_contacts_count.csv"  # change later
 
   afp_contacts_count<- api_case_sub3 |>
     dplyr::mutate(
@@ -2872,14 +2870,19 @@ s1_clean_case_table <- function(path, crosswalk,
     dplyr::arrange(`Place Admin 0`, Year, EPID)
 
   if (nrow(afp_contacts_count) > 0) {
-    output_file <- file.path(
-      output_dir,
-      paste0("afp_contacts_count", format(Sys.Date(), "%Y-%m-%d"), ".csv")
-    )
-    readr::write_csv(afp_contacts_count, output_file)
-    cli::cli_alert_warning(paste0(
-      "AFP check: Found ", nrow(afp_contacts_count),
-      " records. CSV saved to: ", output_file
+    invisible(capture.output(
+      tidypolis_io(
+        io = "write",
+        file_path = paste0(
+          polis_data_folder, "/", output_folder_name,
+          "/afp_contacts_count.csv"
+        ),
+        obj = afp_contacts_count |>
+          dplyr::select(
+            `Place Admin 0`, EPID, `Date of Onset`,
+            `Stool 1 Collection Date`, `Stool 2 Collection Date`
+          )
+      )
     ))
   } else {
     cli::cli_alert_success("AFP check: No matches found.")


### PR DESCRIPTION
This step adds a check that finds epids that end with c, cc, or HC that are classified as afp. It also uses the Stool2Collection date as a filter. 